### PR TITLE
Load resolution of texture operations from settings

### DIFF
--- a/Mechtatel/settings.json
+++ b/Mechtatel/settings.json
@@ -20,6 +20,10 @@
         "engine": "VULKAN",
         "imageFormat": "SRGB"
     },
+    "textureOperation": {
+        "width": -1,
+        "height": -1
+    },
     "vulkan": {
         "enableValidationLayer": true,
         "preferablePhysicalDeviceIndex": 0,

--- a/Mechtatel/settings.json
+++ b/Mechtatel/settings.json
@@ -22,7 +22,8 @@
     },
     "textureOperation": {
         "width": -1,
-        "height": -1
+        "height": -1,
+        "changeExtentOnRecreate": true
     },
     "vulkan": {
         "enableValidationLayer": true,

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MttHeadlessInstance.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MttHeadlessInstance.java
@@ -44,7 +44,7 @@ public class MttHeadlessInstance {
         shouldClose = false;
         instanceId = UUID.randomUUID().toString();
         this.mtt = mtt;
-        vulkanImplHeadless = new MttVulkanImplHeadless(settings.vulkanSettings, width, height);
+        vulkanImplHeadless = new MttVulkanImplHeadless(width, height);
 
         //Set up ImGui =====
         imguiContext = ImGui.createContext();

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MttSettings.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MttSettings.java
@@ -73,6 +73,16 @@ public class MttSettings {
         }
     }
 
+    public static class TextureOperationSettings {
+        public int width;
+        public int height;
+
+        public TextureOperationSettings() {
+            width = -1;
+            height = -1;
+        }
+    }
+
     public static class VulkanSettings {
         public static class AppInfo {
             public String name;
@@ -113,6 +123,8 @@ public class MttSettings {
     public SystemSettings systemSettings;
     @JsonProperty("rendering")
     public RenderingSettings renderingSettings;
+    @JsonProperty("textureOperation")
+    public TextureOperationSettings textureOperation;
     @JsonProperty("vulkan")
     public VulkanSettings vulkanSettings;
 
@@ -123,6 +135,7 @@ public class MttSettings {
         headlessSettings = new HeadlessSettings();
         systemSettings = new SystemSettings();
         renderingSettings = new RenderingSettings();
+        textureOperation = new TextureOperationSettings();
         vulkanSettings = new VulkanSettings();
     }
 

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MttSettings.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MttSettings.java
@@ -76,10 +76,12 @@ public class MttSettings {
     public static class TextureOperationSettings {
         public int width;
         public int height;
+        public boolean changeExtentOnRecreate;
 
         public TextureOperationSettings() {
             width = -1;
             height = -1;
+            changeExtentOnRecreate = true;
         }
     }
 

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MttWindow.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MttWindow.java
@@ -144,7 +144,7 @@ public class MttWindow {
 
         this.mtt = mtt;
 
-        vulkanImpl = new MttVulkanImpl(handle, settings.vulkanSettings);
+        vulkanImpl = new MttVulkanImpl(handle);
 
         keyboard = new Keyboard();
         mouse = new Mouse();


### PR DESCRIPTION
# Overview

Previous implementation uses the extent of swapchain as the resolution of texture operations.
This PR changes it to be loaded from the settings.

Fix to #2
