### PR TITLE
Fix loading of files from JAR

### DIFF
--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/Mechtatel.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/Mechtatel.java
@@ -12,6 +12,7 @@ import org.lwjgl.openal.ALCCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
@@ -82,11 +83,16 @@ public class Mechtatel implements IMechtatelWindowEventHandlers {
             throw new RuntimeException(e);
         }
 
-        nativeLoader.loadLibbulletjme();
-        PhysicalObjects.init(PhysicsSpace.BroadphaseType.DBVT);
-
-        nativeLoader.loadShaderc();
+        try {
+            nativeLoader.loadLibbulletjme();
+            nativeLoader.loadShaderc();
+        } catch (IOException e) {
+            logger.error("Failed to load native library");
+            throw new RuntimeException(e);
+        }
         //==========
+
+        PhysicalObjects.init(PhysicsSpace.BroadphaseType.DBVT);
 
         MttVulkanInstance.create(settings.vulkanSettings, false);
         MttTexture.setImageFormat(settings.renderingSettings.imageFormat);

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MechtatelHeadless.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MechtatelHeadless.java
@@ -12,6 +12,7 @@ import org.lwjgl.openal.ALCCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
@@ -76,10 +77,15 @@ public class MechtatelHeadless implements IMechtatelHeadlessEventHandlers {
             throw new RuntimeException(e);
         }
 
-        nativeLoader.loadLibbulletjme();
-        PhysicalObjects.init(PhysicsSpace.BroadphaseType.DBVT);
+        try {
+            nativeLoader.loadLibbulletjme();
+            nativeLoader.loadShaderc();
+        } catch (IOException e) {
+            logger.error("Failed to load native library");
+            throw new RuntimeException(e);
+        }
 
-        nativeLoader.loadShaderc();
+        PhysicalObjects.init(PhysicsSpace.BroadphaseType.DBVT);
 
         MttVulkanInstance.create(settings.vulkanSettings, false);
         MttTexture.setImageFormat(settings.renderingSettings.imageFormat);

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/util/ShaderSPIRVUtils.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/util/ShaderSPIRVUtils.java
@@ -2,11 +2,11 @@ package com.github.maeda6uiui.mechtatel.core.vulkan.util;
 
 import org.lwjgl.system.NativeResource;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import static org.lwjgl.system.MemoryUtil.NULL;
 import static org.lwjgl.util.shaderc.Shaderc.*;
@@ -55,9 +55,9 @@ public class ShaderSPIRVUtils {
             throw new RuntimeException("Failed to create a shader compiler");
         }
 
-        long result = shaderc_compile_into_spv(compiler, source, shaderKind.kind, filepath, "main", NULL);
+        long result = shaderc_compile_into_spv(compiler, source, shaderKind.kind, "", "main", NULL);
         if (result == NULL) {
-            String errorMessage = String.format("Failed to compile a shader %s into SPIR-V", filepath);
+            String errorMessage = String.format("Failed to compile a shader into SPIR-V: %s", filepath);
             throw new RuntimeException(errorMessage);
         }
 
@@ -74,7 +74,13 @@ public class ShaderSPIRVUtils {
     }
 
     public static SPIRV compileShaderFile(URI shaderResource, ShaderKind shaderKind) throws IOException {
-        String source = new String(Files.readAllBytes(Paths.get(shaderResource)));
-        return compileShader(shaderResource.getPath(), source, shaderKind);
+        URL shaderResourceURL = shaderResource.toURL();
+        String source;
+        try (var bis = new BufferedInputStream(shaderResourceURL.openStream())) {
+            byte[] bs = bis.readAllBytes();
+            source = new String(bs);
+        }
+
+        return compileShader(shaderResourceURL.getPath(), source, shaderKind);
     }
 }

--- a/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader.java
+++ b/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader.java
@@ -1,10 +1,9 @@
 package com.github.maeda6uiui.mechtatel.natives.linux;
 
 import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
-import com.jme3.system.NativeLibraryLoader;
+import com.github.maeda6uiui.mechtatel.natives.NativeLoaderUtils;
 
-import java.io.File;
-import java.util.Objects;
+import java.io.IOException;
 
 /**
  * Loads native libraries for Linux
@@ -13,19 +12,12 @@ import java.util.Objects;
  */
 public class MttNativeLoader implements IMttNativeLoader {
     @Override
-    public void loadLibbulletjme() {
-        NativeLibraryLoader.loadLibbulletjme(
-                true,
-                new File(Objects.requireNonNull(MttNativeLoader.class.getResource("/Bin")).getFile()),
-                "Release",
-                "Sp"
-        );
+    public void loadLibbulletjme() throws IOException {
+        NativeLoaderUtils.loadNativeLibFromJar(this.getClass(), "/Bin/Linux64ReleaseSp_libbulletjme.so");
     }
 
     @Override
-    public void loadShaderc() {
-        String shadercLibFilepath = Objects.requireNonNull(
-                MttNativeLoader.class.getResource("/Bin/libshaderc_shared.so")).getFile();
-        System.load(shadercLibFilepath);
+    public void loadShaderc() throws IOException {
+        NativeLoaderUtils.loadNativeLibFromJar(this.getClass(), "/Bin/libshaderc_shared.so");
     }
 }

--- a/mechtatel-natives-macos/src/main/java/com/github/maeda6uiui/mechtatel/natives/macos/MttNativeLoader.java
+++ b/mechtatel-natives-macos/src/main/java/com/github/maeda6uiui/mechtatel/natives/macos/MttNativeLoader.java
@@ -1,10 +1,9 @@
 package com.github.maeda6uiui.mechtatel.natives.macos;
 
 import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
-import com.jme3.system.NativeLibraryLoader;
+import com.github.maeda6uiui.mechtatel.natives.NativeLoaderUtils;
 
-import java.io.File;
-import java.util.Objects;
+import java.io.IOException;
 
 /**
  * Loads native libraries for macOS
@@ -13,19 +12,12 @@ import java.util.Objects;
  */
 public class MttNativeLoader implements IMttNativeLoader {
     @Override
-    public void loadLibbulletjme() {
-        NativeLibraryLoader.loadLibbulletjme(
-                true,
-                new File(Objects.requireNonNull(MttNativeLoader.class.getResource("/Bin")).getFile()),
-                "Release",
-                "Sp"
-        );
+    public void loadLibbulletjme() throws IOException {
+        NativeLoaderUtils.loadNativeLibFromJar(this.getClass(), "/Bin/MacOSX64ReleaseSp_libbulletjme.dylib");
     }
 
     @Override
-    public void loadShaderc() {
-        String shadercLibFilepath = Objects.requireNonNull(
-                MttNativeLoader.class.getResource("/Bin/libshaderc_shared.dylib")).getFile();
-        System.load(shadercLibFilepath);
+    public void loadShaderc() throws IOException {
+        NativeLoaderUtils.loadNativeLibFromJar(this.getClass(), "/Bin/libshaderc_shared.dylib");
     }
 }

--- a/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader.java
+++ b/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader.java
@@ -1,10 +1,9 @@
 package com.github.maeda6uiui.mechtatel.natives.windows;
 
 import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
-import com.jme3.system.NativeLibraryLoader;
+import com.github.maeda6uiui.mechtatel.natives.NativeLoaderUtils;
 
-import java.io.File;
-import java.util.Objects;
+import java.io.IOException;
 
 /**
  * Loads native libraries for Windows
@@ -13,19 +12,12 @@ import java.util.Objects;
  */
 public class MttNativeLoader implements IMttNativeLoader {
     @Override
-    public void loadLibbulletjme() {
-        NativeLibraryLoader.loadLibbulletjme(
-                true,
-                new File(Objects.requireNonNull(MttNativeLoader.class.getResource("/Bin")).getFile()),
-                "Release",
-                "Sp"
-        );
+    public void loadLibbulletjme() throws IOException {
+        NativeLoaderUtils.loadNativeLibFromJar(this.getClass(), "/Bin/Windows64ReleaseSp_bulletjme.dll");
     }
 
     @Override
-    public void loadShaderc() {
-        String shadercLibFilepath = Objects.requireNonNull(
-                MttNativeLoader.class.getResource("/Bin/shaderc_shared.dll")).getFile();
-        System.load(shadercLibFilepath);
+    public void loadShaderc() throws IOException {
+        NativeLoaderUtils.loadNativeLibFromJar(this.getClass(), "/Bin/shaderc_shared.dll");
     }
 }

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/IMttNativeLoader.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/IMttNativeLoader.java
@@ -1,12 +1,14 @@
 package com.github.maeda6uiui.mechtatel.natives;
 
+import java.io.IOException;
+
 /**
  * Interface of native library loader
  *
  * @author maeda6uiui
  */
 public interface IMttNativeLoader {
-    void loadLibbulletjme();
+    void loadLibbulletjme() throws IOException;
 
-    void loadShaderc();
+    void loadShaderc() throws IOException;
 }

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/NativeLoaderUtils.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/NativeLoaderUtils.java
@@ -16,7 +16,7 @@ public class NativeLoaderUtils {
      * @param filepath Filepath of the native library
      * @throws IOException If it fails to load the native library
      */
-    public static void loadNativeLibFromJar(Class<IMttNativeLoader> clazz, String filepath) throws IOException {
+    public static void loadNativeLibFromJar(Class<? extends IMttNativeLoader> clazz, String filepath) throws IOException {
         try (var bis = new BufferedInputStream(Objects.requireNonNull(clazz.getResourceAsStream(filepath)))) {
             File tempFile = File.createTempFile("lib", ".mttlib");
             tempFile.deleteOnExit();

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/NativeLoaderUtils.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/NativeLoaderUtils.java
@@ -1,0 +1,35 @@
+package com.github.maeda6uiui.mechtatel.natives;
+
+import java.io.*;
+import java.util.Objects;
+
+/**
+ * Utility methods for native loader
+ *
+ * @author maeda6uiui
+ */
+public class NativeLoaderUtils {
+    /**
+     * Loads a native library contained in a JAR file.
+     *
+     * @param clazz    Class to call {@link Class#getResourceAsStream(String)}
+     * @param filepath Filepath of the native library
+     * @throws IOException If it fails to load the native library
+     */
+    public static void loadNativeLibFromJar(Class<IMttNativeLoader> clazz, String filepath) throws IOException {
+        try (var bis = new BufferedInputStream(Objects.requireNonNull(clazz.getResourceAsStream(filepath)))) {
+            File tempFile = File.createTempFile("lib", ".mttlib");
+            tempFile.deleteOnExit();
+
+            try (var bos = new BufferedOutputStream(new FileOutputStream(tempFile))) {
+                var buffer = new byte[4096];
+                int bytesRead;
+                while ((bytesRead = bis.read(buffer)) != -1) {
+                    bos.write(buffer, 0, bytesRead);
+                }
+            }
+
+            System.load(tempFile.getAbsolutePath());
+        }
+    }
+}


### PR DESCRIPTION
# Overview

Previous implementation failed to load files from inside a JAR file, which led the Mechtatel engine not to start because required native libraries couldn't be loaded.
This PR fixes the issue by applying following changes:

- Create a temp file for a native library and then load it
- Load shader code via URL

I didn't think of this issue very well as all previous tests ran in the presence of already extracted files on my local environment.
I'll continue to work on this issue and do some refactoring in next PRs.
