### PR TITLE
Apply transformation to normal vector

### DIFF
--- a/mechtatel-core/src/main/resources/Standard/Shader/GBuffer/albedo.vert
+++ b/mechtatel-core/src/main/resources/Standard/Shader/GBuffer/albedo.vert
@@ -30,7 +30,7 @@ layout(location=0) out vec4 fragColor;
 layout(location=1) out vec2 fragTexCoords;
 
 void process3DDrawing(){
-    vec4 initPos=vec4(0.0,0.0,0.0,0.0);
+    vec4 accumPos=vec4(0.0,0.0,0.0,0.0);
 
     int count=0;
     for(int i=0;i<min(MAX_NUM_WEIGHTS,4);i++){
@@ -39,17 +39,17 @@ void process3DDrawing(){
 
         if(boneIndex>=0){
             vec4 tmpPos=animation.boneMatrices[boneIndex]*vec4(inPosition,1.0);
-            initPos+=weight*tmpPos;
+            accumPos+=weight*tmpPos;
 
             count++;
         }
     }
 
     if(count==0){
-        initPos=vec4(inPosition,1.0);
+        accumPos=vec4(inPosition,1.0);
     }
 
-    gl_Position=camera.proj*camera.view*pc.model*vec4(initPos.xyz,1.0);
+    gl_Position=camera.proj*camera.view*pc.model*vec4(accumPos.xyz,1.0);
 }
 
 void process2DDrawing(){

--- a/mechtatel-core/src/main/resources/Standard/Shader/GBuffer/properties.vert
+++ b/mechtatel-core/src/main/resources/Standard/Shader/GBuffer/properties.vert
@@ -57,7 +57,7 @@ void process3DDrawing(){
     gl_Position=camera.proj*camera.view*pc.model*vec4(accumPos.xyz,1.0);
 
     fragPosition=(pc.model*vec4(accumPos.xyz,1.0)).xyz;
-    fragNormal=(pc.model*vec4(accumNormal.xyz,1.0)).xyz;
+    fragNormal=(pc.model*vec4(accumNormal.xyz,0.0)).xyz;
 }
 
 void process2DDrawing(){

--- a/mechtatel-core/src/main/resources/Standard/Shader/GBuffer/properties.vert
+++ b/mechtatel-core/src/main/resources/Standard/Shader/GBuffer/properties.vert
@@ -30,8 +30,8 @@ layout(location=0) out vec3 fragPosition;
 layout(location=1) out vec3 fragNormal;
 
 void process3DDrawing(){
-    vec4 initPos=vec4(0.0,0.0,0.0,0.0);
-    vec4 initNormal=vec4(0.0,0.0,0.0,0.0);
+    vec4 accumPos=vec4(0.0,0.0,0.0,0.0);
+    vec4 accumNormal=vec4(0.0,0.0,0.0,0.0);
 
     int count=0;
     for(int i=0;i<min(MAX_NUM_WEIGHTS,4);i++){
@@ -40,24 +40,24 @@ void process3DDrawing(){
         
         if(boneIndex>=0){
             vec4 tmpPos=animation.boneMatrices[boneIndex]*vec4(inPosition,1.0);
-            initPos+=weight*tmpPos;
+            accumPos+=weight*tmpPos;
 
             vec4 tmpNormal=animation.boneMatrices[boneIndex]*vec4(inNormal,0.0);
-            initNormal+=weight*tmpNormal;
+            accumNormal+=weight*tmpNormal;
 
             count++;
         }
     }
 
     if(count==0){
-        initPos=vec4(inPosition,1.0);
-        initNormal=vec4(inNormal,0.0);
+        accumPos=vec4(inPosition,1.0);
+        accumNormal=vec4(inNormal,0.0);
     }
 
-    gl_Position=camera.proj*camera.view*pc.model*vec4(initPos.xyz,1.0);
+    gl_Position=camera.proj*camera.view*pc.model*vec4(accumPos.xyz,1.0);
 
-    fragPosition=(pc.model*vec4(initPos.xyz,1.0)).xyz;
-    fragNormal=initNormal.xyz;
+    fragPosition=(pc.model*vec4(accumPos.xyz,1.0)).xyz;
+    fragNormal=(pc.model*vec4(accumNormal.xyz,1.0)).xyz;
 }
 
 void process2DDrawing(){

--- a/mechtatel-core/src/main/resources/Standard/Shader/ShadowMapping/pass_1.vert
+++ b/mechtatel-core/src/main/resources/Standard/Shader/ShadowMapping/pass_1.vert
@@ -23,7 +23,7 @@ layout(location=4) in vec4 inBoneWeights;
 layout(location=5) in ivec4 inBoneIndices;
 
 void main(){
-    vec4 initPos=vec4(0.0,0.0,0.0,0.0);
+    vec4 accumPos=vec4(0.0,0.0,0.0,0.0);
 
     int count=0;
     for(int i=0;i<min(MAX_NUM_WEIGHTS,4);i++){
@@ -32,15 +32,15 @@ void main(){
 
         if(boneIndex>=0){
             vec4 tmpPos=animation.boneMatrices[boneIndex]*vec4(inPosition,1.0);
-            initPos+=weight*tmpPos;
+            accumPos+=weight*tmpPos;
 
             count++;
         }
     }
 
     if(count==0){
-        initPos=vec4(inPosition,1.0);
+        accumPos=vec4(inPosition,1.0);
     }
 
-    gl_Position=passInfo.lightProj*passInfo.lightView*pc.model*vec4(initPos.xyz,1.0);
+    gl_Position=passInfo.lightProj*passInfo.lightView*pc.model*vec4(accumPos.xyz,1.0);
 }

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ParallelLightTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ParallelLightTest.java
@@ -1,0 +1,81 @@
+package com.github.maeda6uiui.mechtatel;
+
+import com.github.maeda6uiui.mechtatel.core.Mechtatel;
+import com.github.maeda6uiui.mechtatel.core.MttSettings;
+import com.github.maeda6uiui.mechtatel.core.MttWindow;
+import com.github.maeda6uiui.mechtatel.core.camera.FreeCamera;
+import com.github.maeda6uiui.mechtatel.core.input.keyboard.KeyCode;
+import com.github.maeda6uiui.mechtatel.core.postprocessing.PostProcessingProperties;
+import com.github.maeda6uiui.mechtatel.core.screen.MttScreen;
+import com.github.maeda6uiui.mechtatel.core.screen.component.MttModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class ParallelLightTest extends Mechtatel {
+    private static final Logger logger = LoggerFactory.getLogger(ParallelLightTest.class);
+
+    public ParallelLightTest(MttSettings settings) {
+        super(settings);
+        this.run();
+    }
+
+    public static void main(String[] args) {
+        MttSettings
+                .load("./Mechtatel/settings.json")
+                .ifPresentOrElse(
+                        ParallelLightTest::new,
+                        () -> logger.error("Failed to load settings")
+                );
+    }
+
+    private MttScreen mainScreen;
+    private MttModel cube;
+    private FreeCamera camera;
+
+    @Override
+    public void onCreate(MttWindow window) {
+        mainScreen = window.createScreen(
+                new MttScreen.MttScreenCreateInfo()
+                        .setPostProcessingNaborNames(List.of("parallel_light"))
+        );
+
+        PostProcessingProperties ppProp = mainScreen.getPostProcessingProperties();
+        ppProp.createParallelLight();
+
+        try {
+            cube = mainScreen.createModel(Paths.get("./Mechtatel/Standard/Model/Cube/cube.obj"));
+        } catch (IOException e) {
+            logger.error("Error", e);
+            window.close();
+
+            return;
+        }
+
+        camera = new FreeCamera(mainScreen.getCamera());
+    }
+
+    @Override
+    public void onUpdate(MttWindow window) {
+        camera.translate(
+                window.getKeyboardPressingCount(KeyCode.W),
+                window.getKeyboardPressingCount(KeyCode.S),
+                window.getKeyboardPressingCount(KeyCode.A),
+                window.getKeyboardPressingCount(KeyCode.D)
+        );
+        camera.rotate(
+                window.getKeyboardPressingCount(KeyCode.UP),
+                window.getKeyboardPressingCount(KeyCode.DOWN),
+                window.getKeyboardPressingCount(KeyCode.LEFT),
+                window.getKeyboardPressingCount(KeyCode.RIGHT)
+        );
+
+        cube.rotY(0.01f);
+
+        mainScreen.draw();
+        window.present(mainScreen);
+    }
+}

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ParallelLightTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ParallelLightTest.java
@@ -8,6 +8,7 @@ import com.github.maeda6uiui.mechtatel.core.input.keyboard.KeyCode;
 import com.github.maeda6uiui.mechtatel.core.postprocessing.PostProcessingProperties;
 import com.github.maeda6uiui.mechtatel.core.screen.MttScreen;
 import com.github.maeda6uiui.mechtatel.core.screen.component.MttModel;
+import org.joml.Vector3f;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,7 @@ public class ParallelLightTest extends Mechtatel {
 
     private MttScreen mainScreen;
     private MttModel cube;
+    private MttModel dupCube;
     private FreeCamera camera;
 
     @Override
@@ -55,6 +57,9 @@ public class ParallelLightTest extends Mechtatel {
             return;
         }
 
+        dupCube = mainScreen.duplicateModel(cube);
+        dupCube.translate(new Vector3f(3.0f, 0.0f, 0.0f));
+
         camera = new FreeCamera(mainScreen.getCamera());
     }
 
@@ -74,6 +79,7 @@ public class ParallelLightTest extends Mechtatel {
         );
 
         cube.rotY(0.01f);
+        dupCube.rotY(0.01f);
 
         mainScreen.draw();
         window.present(mainScreen);

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/PhysicsObjectTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/PhysicsObjectTest.java
@@ -9,6 +9,7 @@ import com.github.maeda6uiui.mechtatel.core.physics.MttDefaultPhysicsSpace;
 import com.github.maeda6uiui.mechtatel.core.physics.MttPhysicsBox;
 import com.github.maeda6uiui.mechtatel.core.physics.MttPhysicsMesh;
 import com.github.maeda6uiui.mechtatel.core.physics.MttPhysicsObject;
+import com.github.maeda6uiui.mechtatel.core.postprocessing.PostProcessingProperties;
 import com.github.maeda6uiui.mechtatel.core.screen.MttScreen;
 import com.github.maeda6uiui.mechtatel.core.screen.component.MttComponent;
 import com.github.maeda6uiui.mechtatel.core.screen.component.MttModel;
@@ -43,18 +44,25 @@ public class PhysicsObjectTest extends Mechtatel {
     private MttModel box;
     private List<MttPhysicsObject> physicsObjects;
 
+    private MttScreen mainScreen;
     private FreeCamera camera;
 
     private Random random;
 
     @Override
     public void onCreate(MttWindow window) {
-        MttScreen defaultScreen = window.getDefaultScreen();
+        mainScreen = window.createScreen(
+                new MttScreen.MttScreenCreateInfo()
+                        .setPostProcessingNaborNames(List.of("parallel_light"))
+        );
+
+        PostProcessingProperties ppProp = mainScreen.getPostProcessingProperties();
+        ppProp.createParallelLight();
 
         try {
-            plane = defaultScreen.createModel(Paths.get("./Mechtatel/Standard/Model/Plane/plane.obj"));
+            plane = mainScreen.createModel(Paths.get("./Mechtatel/Standard/Model/Plane/plane.obj"));
 
-            box = defaultScreen.createModel(Paths.get("./Mechtatel/Standard/Model/Cube/cube.obj"));
+            box = mainScreen.createModel(Paths.get("./Mechtatel/Standard/Model/Cube/cube.obj"));
             box.setVisible(false);
         } catch (IOException e) {
             logger.error("Error", e);
@@ -68,7 +76,7 @@ public class PhysicsObjectTest extends Mechtatel {
         phPlane.getBody().setFriction(0.5f);
         MttDefaultPhysicsSpace.get().ifPresent(v -> v.addCollisionObject(phPlane.getBody()));
 
-        camera = new FreeCamera(defaultScreen.getCamera());
+        camera = new FreeCamera(mainScreen.getCamera());
 
         physicsObjects = new ArrayList<>();
 
@@ -97,10 +105,8 @@ public class PhysicsObjectTest extends Mechtatel {
         x *= signX;
         z *= signZ;
 
-        MttScreen defaultScreen = window.getDefaultScreen();
-
         if (window.getKeyboardPressingCount(KeyCode.KEY_1) == 1) {
-            var dupBox = defaultScreen.duplicateModel(box);
+            var dupBox = mainScreen.duplicateModel(box);
             dupBox.rescale(new Vector3f(0.5f, 0.5f, 0.5f));
 
             var phBox = new MttPhysicsBox(0.5f, 1.0f);
@@ -121,7 +127,7 @@ public class PhysicsObjectTest extends Mechtatel {
 
         physicsObjects.forEach(MttPhysicsObject::syncComponents);
 
-        defaultScreen.draw();
-        window.present(defaultScreen);
+        mainScreen.draw();
+        window.present(mainScreen);
     }
 }


### PR DESCRIPTION
# Overview

Current implementation does not simulate lighting effects of rotating models because model matrix is not applied to normal vectors.
This PR fixes that issue.
