### PR TITLE
Rename nabors to prevent name collisions

### DIFF
--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/nabor/fseffect/FullScreenEffectNaborChain.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/nabor/fseffect/FullScreenEffectNaborChain.java
@@ -94,7 +94,7 @@ public class FullScreenEffectNaborChain {
                 );
             } else {
                 fseNabor = switch (naborName) {
-                    case "gaussian_blur" ->
+                    case "fse.gaussian_blur" ->
                             new GaussianBlurNabor(device, gaussianBlurVertShaderResource, gaussianBlurFragShaderResource);
                     default -> throw new IllegalArgumentException("Unknown nabor name specified: " + naborName);
                 };
@@ -151,7 +151,7 @@ public class FullScreenEffectNaborChain {
             String naborName,
             FullScreenEffectNabor fseNabor,
             FullScreenEffectProperties fseProperties) {
-        if (naborName.equals("gaussian_blur")) {
+        if (naborName.equals("fse.gaussian_blur")) {
             long gaussianBlurInfoUBOMemory = fseNabor.getUniformBufferMemory(0);
             var gaussianBlurInfoUBO = new GaussianBlurInfoUBO(fseProperties.gaussianBlurInfo);
             gaussianBlurInfoUBO.update(device, gaussianBlurInfoUBOMemory);

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/nabor/postprocessing/PostProcessingNaborChain.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/nabor/postprocessing/PostProcessingNaborChain.java
@@ -141,14 +141,14 @@ public class PostProcessingNaborChain {
                 );
             } else {
                 ppNabor = switch (naborName) {
-                    case "fog" -> new FogNabor(device, fogVertShaderResource, fogFragShaderResource);
-                    case "parallel_light" ->
+                    case "pp.fog" -> new FogNabor(device, fogVertShaderResource, fogFragShaderResource);
+                    case "pp.parallel_light" ->
                             new ParallelLightNabor(device, parallelLightVertShaderResource, parallelLightFragShaderResource);
-                    case "point_light" ->
+                    case "pp.point_light" ->
                             new PointLightNabor(device, pointLightVertShaderResource, pointLightFragShaderResource);
-                    case "spotlight" ->
+                    case "pp.spotlight" ->
                             new SpotlightNabor(device, spotlightVertShaderResource, spotlightFragShaderResource);
-                    case "simple_blur" ->
+                    case "pp.simple_blur" ->
                             new SimpleBlurNabor(device, simpleBlurVertShaderResource, simpleBlurFragShaderResource);
                     default -> throw new IllegalArgumentException("Unknown nabor name specified: " + naborName);
                 };
@@ -207,7 +207,7 @@ public class PostProcessingNaborChain {
             Camera camera,
             PostProcessingProperties ppProperties) {
         switch (naborName) {
-            case "fog": {
+            case "pp.fog": {
                 long cameraUBOMemory = ppNabor.getUniformBufferMemory(0);
                 var cameraUBO = new CameraUBO(camera);
                 cameraUBO.update(device, cameraUBOMemory);
@@ -218,7 +218,7 @@ public class PostProcessingNaborChain {
             }
             break;
 
-            case "parallel_light": {
+            case "pp.parallel_light": {
                 long cameraUBOMemory = ppNabor.getUniformBufferMemory(0);
                 var cameraUBO = new CameraUBO(camera);
                 cameraUBO.update(device, cameraUBOMemory);
@@ -239,7 +239,7 @@ public class PostProcessingNaborChain {
             }
             break;
 
-            case "point_light": {
+            case "pp.point_light": {
                 long cameraUBOMemory = ppNabor.getUniformBufferMemory(0);
                 var cameraUBO = new CameraUBO(camera);
                 cameraUBO.update(device, cameraUBOMemory);
@@ -260,7 +260,7 @@ public class PostProcessingNaborChain {
             }
             break;
 
-            case "spotlight": {
+            case "pp.spotlight": {
                 long cameraUBOMemory = ppNabor.getUniformBufferMemory(0);
                 var cameraUBO = new CameraUBO(camera);
                 cameraUBO.update(device, cameraUBOMemory);
@@ -281,7 +281,7 @@ public class PostProcessingNaborChain {
             }
             break;
 
-            case "simple_blur": {
+            case "pp.simple_blur": {
                 long blurInfoUBOMemory = ppNabor.getUniformBufferMemory(0);
                 var blurInfoUBO = new SimpleBlurInfoUBO(ppProperties.simpleBlurInfo);
                 blurInfoUBO.update(device, blurInfoUBOMemory);

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/CustomizablePostProcessingNaborTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/CustomizablePostProcessingNaborTest.java
@@ -69,8 +69,8 @@ public class CustomizablePostProcessingNaborTest extends Mechtatel {
         mainScreen = window.createScreen(
                 new MttScreen.MttScreenCreateInfo()
                         .setUseShadowMapping(true)
-                        .setPostProcessingNaborNames(List.of("sepia"))
-                        .setCustomizablePostProcessingNaborInfos(Map.of("sepia", naborInfo))
+                        .setPostProcessingNaborNames(List.of("pp.sepia"))
+                        .setCustomizablePostProcessingNaborInfos(Map.of("pp.sepia", naborInfo))
         );
         PostProcessingProperties ppProperties = mainScreen.getPostProcessingProperties();
         ppProperties.createParallelLight();

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/GaussianBlurTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/GaussianBlurTest.java
@@ -39,7 +39,7 @@ public class GaussianBlurTest extends Mechtatel {
     public void onCreate(MttWindow window) {
         mainScreen = window.createScreen(
                 new MttScreen.MttScreenCreateInfo()
-                        .setFullScreenEffectNaborNames(List.of("gaussian_blur"))
+                        .setFullScreenEffectNaborNames(List.of("fse.gaussian_blur"))
         );
 
         try {

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ParallelLightTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ParallelLightTest.java
@@ -42,7 +42,7 @@ public class ParallelLightTest extends Mechtatel {
     public void onCreate(MttWindow window) {
         mainScreen = window.createScreen(
                 new MttScreen.MttScreenCreateInfo()
-                        .setPostProcessingNaborNames(List.of("parallel_light"))
+                        .setPostProcessingNaborNames(List.of("pp.parallel_light"))
         );
 
         PostProcessingProperties ppProp = mainScreen.getPostProcessingProperties();

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/PhysicsObjectTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/PhysicsObjectTest.java
@@ -53,7 +53,7 @@ public class PhysicsObjectTest extends Mechtatel {
     public void onCreate(MttWindow window) {
         mainScreen = window.createScreen(
                 new MttScreen.MttScreenCreateInfo()
-                        .setPostProcessingNaborNames(List.of("parallel_light"))
+                        .setPostProcessingNaborNames(List.of("pp.parallel_light"))
         );
 
         PostProcessingProperties ppProp = mainScreen.getPostProcessingProperties();

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ScreenshotTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ScreenshotTest.java
@@ -45,7 +45,7 @@ public class ScreenshotTest extends Mechtatel {
         mainScreen = window.createScreen(
                 new MttScreen.MttScreenCreateInfo()
                         .setUseShadowMapping(true)
-                        .setPostProcessingNaborNames(Arrays.asList("parallel_light", "fog"))
+                        .setPostProcessingNaborNames(Arrays.asList("pp.parallel_light", "pp.fog"))
         );
 
         PostProcessingProperties ppProperties = mainScreen.getPostProcessingProperties();

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ShadowMappingTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ShadowMappingTest.java
@@ -50,7 +50,7 @@ public class ShadowMappingTest extends Mechtatel {
         mainScreen = window.createScreen(
                 new MttScreen.MttScreenCreateInfo()
                         .setUseShadowMapping(true)
-                        .setPostProcessingNaborNames(Arrays.asList("parallel_light", "fog"))
+                        .setPostProcessingNaborNames(Arrays.asList("pp.parallel_light", "pp.fog"))
         );
 
         PostProcessingProperties ppProperties = mainScreen.getPostProcessingProperties();

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/SimpleBlurTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/SimpleBlurTest.java
@@ -40,7 +40,7 @@ public class SimpleBlurTest extends Mechtatel {
     public void onCreate(MttWindow window) {
         mainScreen = window.createScreen(
                 new MttScreen.MttScreenCreateInfo()
-                        .setPostProcessingNaborNames(List.of("simple_blur"))
+                        .setPostProcessingNaborNames(List.of("pp.simple_blur"))
         );
 
         try {

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/SkeletalAnimationTest2.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/SkeletalAnimationTest2.java
@@ -72,7 +72,7 @@ public class SkeletalAnimationTest2 extends Mechtatel {
         mainScreen = window.createScreen(
                 new MttScreen.MttScreenCreateInfo()
                         .setUseShadowMapping(true)
-                        .setPostProcessingNaborNames(Arrays.asList("parallel_light"))
+                        .setPostProcessingNaborNames(Arrays.asList("pp.parallel_light"))
         );
 
         //Create light

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/SphereAndCapsuleTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/SphereAndCapsuleTest.java
@@ -49,7 +49,7 @@ public class SphereAndCapsuleTest extends Mechtatel {
     public void onCreate(MttWindow window) {
         mainScreen = window.createScreen(
                 new MttScreen.MttScreenCreateInfo()
-                        .setPostProcessingNaborNames(List.of("parallel_light"))
+                        .setPostProcessingNaborNames(List.of("pp.parallel_light"))
         );
 
         PostProcessingProperties ppProp = mainScreen.getPostProcessingProperties();

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/TexturedScreenTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/TexturedScreenTest.java
@@ -54,7 +54,7 @@ public class TexturedScreenTest extends Mechtatel {
 
         secondaryScreen = window.createScreen(
                 new MttScreen.MttScreenCreateInfo()
-                        .setPostProcessingNaborNames(List.of("parallel_light"))
+                        .setPostProcessingNaborNames(List.of("pp.parallel_light"))
                         .setDepthImageWidth(1024)
                         .setDepthImageHeight(1024)
                         .setScreenWidth(512)


### PR DESCRIPTION
# Overview

Renamed nabors to prevent name collisions.
New names have a following prefix:

post-processing: `pp`
full-screen effect: `fse`
