### PR TITLE
Support usage of ImGui.image()

### DIFF
--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/screen/component/MttImGui.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/screen/component/MttImGui.java
@@ -79,8 +79,7 @@ public class MttImGui extends MttComponent {
                 dq.device(),
                 vulkanImplCommon.getCommandPool(),
                 dq.graphicsQueue(),
-                screen.getVulkanScreen(),
-                vkTexture
+                screen.getVulkanScreen()
         );
         this.associateVulkanComponents(vkImGui);
     }

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/component/VkMttImGui.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/component/VkMttImGui.java
@@ -3,7 +3,6 @@ package com.github.maeda6uiui.mechtatel.core.vulkan.screen.component;
 import com.github.maeda6uiui.mechtatel.core.screen.component.IMttComponentForVkMttComponent;
 import com.github.maeda6uiui.mechtatel.core.screen.component.MttVertex;
 import com.github.maeda6uiui.mechtatel.core.vulkan.screen.VkMttScreen;
-import com.github.maeda6uiui.mechtatel.core.vulkan.screen.texture.VkMttTexture;
 import com.github.maeda6uiui.mechtatel.core.vulkan.util.BufferUtils;
 import imgui.ImDrawData;
 import org.joml.Vector2f;
@@ -33,7 +32,6 @@ public class VkMttImGui extends VkMttComponent {
     private long commandPool;
     private VkQueue graphicsQueue;
 
-    private VkMttTexture texture;
     private ImDrawData drawData;
 
     private Map<Integer, Long> vertexBuffers;
@@ -42,23 +40,17 @@ public class VkMttImGui extends VkMttComponent {
     private Map<Integer, Long> indexBufferMemories;
     private Map<Integer, Integer> numIndicesMap;
 
-    private boolean isExternalTexture;
-
     public VkMttImGui(
             IMttComponentForVkMttComponent mttComponent,
             VkDevice device,
             long commandPool,
             VkQueue graphicsQueue,
-            VkMttScreen screen,
-            VkMttTexture texture) {
+            VkMttScreen screen) {
         super(mttComponent, screen, "gbuffer_imgui");
 
         this.device = device;
         this.commandPool = commandPool;
         this.graphicsQueue = graphicsQueue;
-
-        this.texture = texture;
-        isExternalTexture = true;
 
         vertexBuffers = new HashMap<>();
         vertexBufferMemories = new HashMap<>();
@@ -69,10 +61,6 @@ public class VkMttImGui extends VkMttComponent {
 
     @Override
     public void cleanup() {
-        if (!isExternalTexture) {
-            texture.cleanup();
-        }
-
         vertexBuffers.values().forEach(v -> vkDestroyBuffer(device, v, null));
         vertexBufferMemories.values().forEach(v -> vkFreeMemory(device, v, null));
         indexBuffers.values().forEach(v -> vkDestroyBuffer(device, v, null));
@@ -219,7 +207,7 @@ public class VkMttImGui extends VkMttComponent {
 
     @Override
     public void draw(VkCommandBuffer commandBuffer, long pipelineLayout) {
-        if (!this.isValid() || !this.isVisible() || texture == null || drawData == null) {
+        if (!this.isValid() || !this.isVisible() || drawData == null) {
             return;
         }
 

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ImGuiImageTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ImGuiImageTest.java
@@ -29,7 +29,7 @@ public class ImGuiImageTest extends Mechtatel {
                 );
     }
 
-    private MttScreen imageScreen;
+    private MttScreen mainScreen;
     private MttScreen imguiScreen;
 
     private MttImGui imgui;
@@ -37,18 +37,18 @@ public class ImGuiImageTest extends Mechtatel {
 
     @Override
     public void onInit(MttWindow initialWindow) {
-        imageScreen = initialWindow.createScreen(
+        mainScreen = initialWindow.createScreen(
                 new MttScreen.MttScreenCreateInfo()
         );
-        imageScreen.createLineSet().addAxes(10.0f).createBuffer();
-        imageScreen.createSphere(1.0f, 16, 16, new Vector4f(1.0f), false);
+        mainScreen.createLineSet().addAxes(10.0f).createBuffer();
+        mainScreen.createSphere(1.0f, 16, 16, new Vector4f(1.0f), false);
 
         imguiScreen = initialWindow.createScreen(
                 new MttScreen.MttScreenCreateInfo()
         );
         imgui = imguiScreen.createImGui();
 
-        texture = imageScreen.texturize(ScreenImageType.COLOR, imguiScreen);
+        texture = mainScreen.texturize(ScreenImageType.COLOR, imguiScreen);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class ImGuiImageTest extends Mechtatel {
             ImGui.image(texture.getVulkanTexture().getAllocationIndex(), 640, 480);
         });
 
-        imageScreen.draw();
+        mainScreen.draw();
         imguiScreen.draw();
         window.present(imguiScreen);
     }

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ImGuiImageTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ImGuiImageTest.java
@@ -8,6 +8,7 @@ import com.github.maeda6uiui.mechtatel.core.screen.ScreenImageType;
 import com.github.maeda6uiui.mechtatel.core.screen.component.MttImGui;
 import com.github.maeda6uiui.mechtatel.core.screen.texture.MttTexture;
 import imgui.ImGui;
+import imgui.flag.ImGuiCond;
 import org.joml.Vector4f;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +55,15 @@ public class ImGuiImageTest extends Mechtatel {
     @Override
     public void onUpdate(MttWindow window) {
         imgui.declare(() -> {
-            ImGui.image(texture.getVulkanTexture().getAllocationIndex(), 640, 480);
+            if (ImGui.begin("Image View")) {
+                ImGui.setWindowSize(640, 480, ImGuiCond.FirstUseEver);
+                ImGui.image(
+                        texture.getVulkanTexture().getAllocationIndex(),
+                        ImGui.getContentRegionAvailX(),
+                        ImGui.getContentRegionAvailY()
+                );
+            }
+            ImGui.end();
         });
 
         mainScreen.draw();

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ImGuiImageTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/ImGuiImageTest.java
@@ -1,0 +1,64 @@
+package com.github.maeda6uiui.mechtatel;
+
+import com.github.maeda6uiui.mechtatel.core.Mechtatel;
+import com.github.maeda6uiui.mechtatel.core.MttSettings;
+import com.github.maeda6uiui.mechtatel.core.MttWindow;
+import com.github.maeda6uiui.mechtatel.core.screen.MttScreen;
+import com.github.maeda6uiui.mechtatel.core.screen.ScreenImageType;
+import com.github.maeda6uiui.mechtatel.core.screen.component.MttImGui;
+import com.github.maeda6uiui.mechtatel.core.screen.texture.MttTexture;
+import imgui.ImGui;
+import org.joml.Vector4f;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ImGuiImageTest extends Mechtatel {
+    private static final Logger logger = LoggerFactory.getLogger(ImGuiImageTest.class);
+
+    public ImGuiImageTest(MttSettings settings) {
+        super(settings);
+        this.run();
+    }
+
+    public static void main(String[] args) {
+        MttSettings
+                .load("./Mechtatel/settings.json")
+                .ifPresentOrElse(
+                        ImGuiImageTest::new,
+                        () -> logger.error("Failed to load settings")
+                );
+    }
+
+    private MttScreen imageScreen;
+    private MttScreen imguiScreen;
+
+    private MttImGui imgui;
+    private MttTexture texture;
+
+    @Override
+    public void onInit(MttWindow initialWindow) {
+        imageScreen = initialWindow.createScreen(
+                new MttScreen.MttScreenCreateInfo()
+        );
+        imageScreen.createLineSet().addAxes(10.0f).createBuffer();
+        imageScreen.createSphere(1.0f, 16, 16, new Vector4f(1.0f), false);
+
+        imguiScreen = initialWindow.createScreen(
+                new MttScreen.MttScreenCreateInfo()
+        );
+        imgui = imguiScreen.createImGui();
+
+        texture = imageScreen.texturize(ScreenImageType.COLOR, imguiScreen);
+    }
+
+    @Override
+    public void onUpdate(MttWindow window) {
+        imgui.declare(() -> {
+            ImGui.image(texture.getVulkanTexture().getAllocationIndex(), 640, 480);
+        });
+
+        imageScreen.draw();
+        imguiScreen.draw();
+        window.present(imguiScreen);
+    }
+}


### PR DESCRIPTION
# Overview

Added support of usage of `ImGui.image()`.

# Usage

Pass the allocation index of the texture to `ImGui.image()`.

```java
ImGui.image(
        texture.getVulkanTexture().getAllocationIndex(),
        ImGui.getContentRegionAvailX(),
        ImGui.getContentRegionAvailY()
);
```

![Screenshot from 2025-01-12 23-03-19](https://github.com/user-attachments/assets/29a79ea5-a87f-4897-b927-f973fb996a56)
