### PR TITLE
Use heap memory when creating set component

### DIFF
--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/component/VkMttLineSet.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/component/VkMttLineSet.java
@@ -77,7 +77,7 @@ public class VkMttLineSet extends VkMttComponent {
     }
 
     public void createBuffer() {
-        BufferUtils.BufferInfo bufferInfo = BufferUtils.createPrimitiveVerticesBufferFromStackMemory(
+        BufferUtils.BufferInfo bufferInfo = BufferUtils.createPrimitiveVerticesBufferFromHeapMemory(
                 device,
                 commandPool,
                 graphicsQueue,

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/component/VkMttTexturedQuadSingleTextureSet.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/component/VkMttTexturedQuadSingleTextureSet.java
@@ -115,7 +115,7 @@ public class VkMttTexturedQuadSingleTextureSet extends VkMttComponent {
     }
 
     public void createBuffers() {
-        BufferUtils.BufferInfo bufferInfo = BufferUtils.createVerticesBufferFromStackMemory(
+        BufferUtils.BufferInfo bufferInfo = BufferUtils.createVerticesBufferFromHeapMemory(
                 device,
                 commandPool,
                 graphicsQueue,
@@ -134,7 +134,7 @@ public class VkMttTexturedQuadSingleTextureSet extends VkMttComponent {
             indices.add(i);
         }
 
-        bufferInfo = BufferUtils.createIndexBufferFromStackMemory(
+        bufferInfo = BufferUtils.createIndexBufferFromHeapMemory(
                 device,
                 commandPool,
                 graphicsQueue,

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/DrawFontTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/DrawFontTest.java
@@ -1,0 +1,50 @@
+package com.github.maeda6uiui.mechtatel;
+
+import com.github.maeda6uiui.mechtatel.core.Mechtatel;
+import com.github.maeda6uiui.mechtatel.core.MttSettings;
+import com.github.maeda6uiui.mechtatel.core.MttWindow;
+import com.github.maeda6uiui.mechtatel.core.screen.MttScreen;
+import com.github.maeda6uiui.mechtatel.core.screen.component.MttFont;
+import org.joml.Vector2f;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.*;
+
+public class DrawFontTest extends Mechtatel {
+    private static final Logger logger = LoggerFactory.getLogger(DrawFontTest.class);
+
+    public DrawFontTest(MttSettings settings) {
+        super(settings);
+        this.run();
+    }
+
+    public static void main(String[] args) {
+        MttSettings
+                .load("./Mechtatel/settings.json")
+                .ifPresentOrElse(
+                        DrawFontTest::new,
+                        () -> logger.error("Failed to load settings")
+                );
+    }
+
+    @Override
+    public void onCreate(MttWindow window) {
+        MttScreen defaultScreen = window.getDefaultScreen();
+        MttFont font = defaultScreen.createFont(
+                new Font(Font.SERIF, Font.PLAIN, 128),
+                true,
+                Color.GREEN,
+                "こんにちは"
+        );
+        font.prepare("こんにちは", new Vector2f(-1.0f));
+        font.createBuffers();
+    }
+
+    @Override
+    public void onUpdate(MttWindow window) {
+        MttScreen defaultScreen = window.getDefaultScreen();
+        defaultScreen.draw();
+        window.present(defaultScreen);
+    }
+}

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/RenderFontTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/RenderFontTest.java
@@ -11,10 +11,10 @@ import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 
-public class DrawFontTest extends Mechtatel {
-    private static final Logger logger = LoggerFactory.getLogger(DrawFontTest.class);
+public class RenderFontTest extends Mechtatel {
+    private static final Logger logger = LoggerFactory.getLogger(RenderFontTest.class);
 
-    public DrawFontTest(MttSettings settings) {
+    public RenderFontTest(MttSettings settings) {
         super(settings);
         this.run();
     }
@@ -23,7 +23,7 @@ public class DrawFontTest extends Mechtatel {
         MttSettings
                 .load("./Mechtatel/settings.json")
                 .ifPresentOrElse(
-                        DrawFontTest::new,
+                        RenderFontTest::new,
                         () -> logger.error("Failed to load settings")
                 );
     }


### PR DESCRIPTION
# Overview

Use heap memory when creating set components to accomodate larger number of vertices.
Added a test code of rendering a font to test if VkMttTexturedQuadSingleTextureSet works as expected.
