### PR TITLE
Add option to limit number of shadow maps to be created

### DIFF
--- a/Mechtatel/settings.json
+++ b/Mechtatel/settings.json
@@ -34,6 +34,7 @@
         "preferablePhysicalDeviceIndex": 0,
         "preferableGraphicsFamilyIndex": 0,
         "preferablePresentFamilyIndex": 0,
-        "albedoMSAASamples": 1
+        "albedoMSAASamples": 1,
+        "numShadowMaps": 1
     }
 }

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ Rendering to multiple windows
 
 ## Progress report
 
+### 2025-04-22
+
+Added an option to limit the number of shadow maps to be created.
+The previous implementation created 16 shadow maps regardless of whether they are used, which may cause wasteful allocation of VRAM.
+New implementation allows to specify the number of shadow maps between 1 and 16, and the default is 1.
+This value can be changed via settings.json (`vulkan.numShadowMaps`).
+
 ### 2025-04-20
 
 Added a test code for audio playback using [LibSoundPlayer](https://github.com/maeda6uiui/LibSoundPlayer).

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MttSettings.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MttSettings.java
@@ -98,6 +98,7 @@ public class MttSettings {
         public int preferableGraphicsFamilyIndex;
         public int preferablePresentFamilyIndex;
         public int albedoMSAASamples;
+        public int numShadowMaps;
 
         public VulkanSettings() {
             enableValidationLayer = false;
@@ -105,6 +106,7 @@ public class MttSettings {
             preferableGraphicsFamilyIndex = -1;
             preferablePresentFamilyIndex = -1;
             albedoMSAASamples = 2;
+            numShadowMaps = 1;
         }
     }
 

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/screen/MttScreen.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/screen/MttScreen.java
@@ -55,6 +55,7 @@ public class MttScreen implements IMttScreenForMttComponent, IMttScreenForMttTex
         public SamplerAddressMode samplerAddressMode;
         public boolean shouldChangeExtentOnRecreate;
         public boolean useShadowMapping;
+        public int numShadowMaps;
         public List<String> ppNaborNames;
         public Map<String, CustomizablePostProcessingNaborInfo> customizablePPNaborInfos;
         public List<String> fseNaborNames;
@@ -70,6 +71,7 @@ public class MttScreen implements IMttScreenForMttComponent, IMttScreenForMttTex
             samplerAddressMode = SamplerAddressMode.REPEAT;
             shouldChangeExtentOnRecreate = true;
             useShadowMapping = false;
+            numShadowMaps = 1;
             ppNaborNames = new ArrayList<>();
             customizablePPNaborInfos = new HashMap<>();
             fseNaborNames = new ArrayList<>();
@@ -118,6 +120,11 @@ public class MttScreen implements IMttScreenForMttComponent, IMttScreenForMttTex
 
         public MttScreenCreateInfo setUseShadowMapping(boolean useShadowMapping) {
             this.useShadowMapping = useShadowMapping;
+            return this;
+        }
+
+        public MttScreenCreateInfo setNumShadowMaps(int numShadowMaps) {
+            this.numShadowMaps = numShadowMaps;
             return this;
         }
 
@@ -203,6 +210,7 @@ public class MttScreen implements IMttScreenForMttComponent, IMttScreenForMttTex
                         ),
                         createInfo.shouldChangeExtentOnRecreate,
                         createInfo.useShadowMapping,
+                        createInfo.numShadowMaps,
                         createInfo.ppNaborNames,
                         createInfo.customizablePPNaborInfos,
                         createInfo.fseNaborNames,
@@ -248,6 +256,7 @@ public class MttScreen implements IMttScreenForMttComponent, IMttScreenForMttTex
                         ),
                         createInfo.shouldChangeExtentOnRecreate,
                         createInfo.useShadowMapping,
+                        createInfo.numShadowMaps,
                         createInfo.ppNaborNames,
                         createInfo.customizablePPNaborInfos,
                         createInfo.fseNaborNames,

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/VkMttScreen.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/VkMttScreen.java
@@ -61,6 +61,7 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
             VkExtent2D extent,
             boolean shouldChangeExtentOnRecreate,
             boolean useShadowMapping,
+            int numShadowMaps,
             List<String> ppNaborNames,
             Map<String, CustomizablePostProcessingNaborInfo> customizablePPNaborInfos,
             List<String> fseNaborNames,
@@ -90,6 +91,7 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
     private int depthImageWidth;
     private int depthImageHeight;
     private int depthImageAspect;
+    private int numShadowMaps;
 
     private PostProcessingNaborChain ppNaborChain;
     private FullScreenEffectNaborChain fseNaborChain;
@@ -104,7 +106,7 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
         shadowMappingNabor.cleanupUserDefImages();
 
         //Shadow depth
-        for (int i = 0; i < ShadowMappingNabor.MAX_NUM_SHADOW_MAPS; i++) {
+        for (int i = 0; i < numShadowMaps; i++) {
             shadowMappingNabor.createUserDefImage(
                     depthImageWidth,
                     depthImageHeight,
@@ -144,6 +146,17 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
         this.depthImageWidth = createInfo.depthImageWidth;
         this.depthImageHeight = createInfo.depthImageHeight;
         this.depthImageAspect = createInfo.depthImageAspect;
+
+        if (createInfo.numShadowMaps > ShadowMappingNabor.MAX_NUM_SHADOW_MAPS) {
+            throw new RuntimeException(
+                    String.format(
+                            "Maximum number of shadow maps is %d, got %d",
+                            ShadowMappingNabor.MAX_NUM_SHADOW_MAPS,
+                            createInfo.numShadowMaps
+                    )
+            );
+        }
+        this.numShadowMaps = createInfo.numShadowMaps;
 
         initialWidth = createInfo.extent.width();
         initialHeight = createInfo.extent.height();
@@ -382,6 +395,7 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
                         extent,
                         shouldChangeExtentOnRecreate,
                         useShadowMapping,
+                        1,
                         ppNaborNames,
                         customizablePPNaborInfos,
                         fseNaborNames,

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/VkMttScreen.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/VkMttScreen.java
@@ -147,10 +147,10 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
         this.depthImageHeight = createInfo.depthImageHeight;
         this.depthImageAspect = createInfo.depthImageAspect;
 
-        if (createInfo.numShadowMaps > ShadowMappingNabor.MAX_NUM_SHADOW_MAPS) {
+        if (createInfo.numShadowMaps <= 0 || createInfo.numShadowMaps > ShadowMappingNabor.MAX_NUM_SHADOW_MAPS) {
             throw new RuntimeException(
                     String.format(
-                            "Maximum number of shadow maps is %d, got %d",
+                            "Number of shadow maps must be between 1 and %d, got %d",
                             ShadowMappingNabor.MAX_NUM_SHADOW_MAPS,
                             createInfo.numShadowMaps
                     )


### PR DESCRIPTION
# Overview

Added an option to limit the number of shadow maps to be created.
Previous implementation creates 16 shadow maps regardless of they are actually used, which may cause wasteful usage of VRAM.
New implementation limits its number to the specified value, and will help optimize VRAM usage.
