### PR TITLE
Publish to Central Portal

### DIFF
--- a/.github/workflows/deploy-artifacts-on-push.yml
+++ b/.github/workflows/deploy-artifacts-on-push.yml
@@ -13,8 +13,8 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy-artifacts.yml
     secrets:
-      ossrhUsername: ${{secrets.OSSRH_USERNAME}}
-      ossrhPassword: ${{secrets.OSSRH_PASSWORD}}
+      centralUsername: ${{secrets.CENTRAL_USERNAME}}
+      centralPassword: ${{secrets.CENTRAL_PASSWORD}}
       gpgKeyId: ${{secrets.GPG_KEY_ID}}
       gpgPrivateKey: ${{secrets.GPG_PRIVATE_KEY}}
       gpgPassphrase: ${{secrets.GPG_PASSPHRASE}}

--- a/.github/workflows/deploy-artifacts.yml
+++ b/.github/workflows/deploy-artifacts.yml
@@ -3,9 +3,9 @@ name: Deploy artifacts to Maven Central
 on:
   workflow_call:
     secrets:
-      ossrhUsername:
+      centralUsername:
         required: true
-      ossrhPassword:
+      centralPassword:
         required: true
       gpgKeyId:
         required: true
@@ -41,9 +41,9 @@ jobs:
           <settings>
             <servers>
               <server>
-                <id>ossrh</id>
-                <username>${{secrets.ossrhUsername}}</username>
-                <password>${{secrets.ossrhPassword}}</password>
+                <id>central</id>
+                <username>${{secrets.centralUsername}}</username>
+                <password>${{secrets.centralPassword}}</password>
               </server>
             </servers>
           </settings>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ God knows if I could complete this work by the time you'd think I'm no more...
 
 ## Try it out
 
+`groupId` is going to be changed to `io.github.maeda6uiui` from the next GA release.
+
 ```xml
 <dependencies>
     <dependency>
@@ -47,14 +49,14 @@ Snapshot builds are available in the Maven Snapshot Repository.
 ```xml
 <dependencies>
     <dependency>
-        <groupId>com.github.dabasan</groupId>
+        <groupId>io.github.maeda6uiui</groupId>
         <artifactId>mechtatel-core</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
-        <groupId>com.github.dabasan</groupId>
+        <groupId>io.github.maeda6uiui</groupId>
         <artifactId>mechtatel-logging</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ God knows if I could complete this work by the time you'd think I'm no more...
 
 ## Try it out
 
-`groupId` is going to be changed to `io.github.maeda6uiui` from the next GA release.
+`groupId` is going to be changed to `io.github.maeda6uiui` in the next GA release.
 
 ```xml
 <dependencies>

--- a/mechtatel-core/pom.xml
+++ b/mechtatel-core/pom.xml
@@ -18,8 +18,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/mechtatel-core/pom.xml
+++ b/mechtatel-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.dabasan</groupId>
         <artifactId>mechtatel</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mechtatel-core</artifactId>

--- a/mechtatel-core/pom.xml
+++ b/mechtatel-core/pom.xml
@@ -148,9 +148,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.dabasan</groupId>
+            <groupId>io.github.maeda6uiui</groupId>
             <artifactId>lib-sound-player-core</artifactId>
-            <version>0.0.1</version>
+            <version>0.0.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/mechtatel-core/pom.xml
+++ b/mechtatel-core/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.dabasan</groupId>
+        <groupId>io.github.maeda6uiui</groupId>
         <artifactId>mechtatel</artifactId>
         <version>0.1.1-SNAPSHOT</version>
     </parent>
@@ -131,18 +131,18 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.dabasan</groupId>
+            <groupId>io.github.maeda6uiui</groupId>
             <artifactId>mechtatel-natives</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.dabasan</groupId>
+            <groupId>io.github.maeda6uiui</groupId>
             <artifactId>${mechtatel.natives}</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github.dabasan</groupId>
+            <groupId>io.github.maeda6uiui</groupId>
             <artifactId>mechtatel-logging</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/mechtatel-logging/pom.xml
+++ b/mechtatel-logging/pom.xml
@@ -18,8 +18,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/mechtatel-logging/pom.xml
+++ b/mechtatel-logging/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.dabasan</groupId>
+        <groupId>io.github.maeda6uiui</groupId>
         <artifactId>mechtatel</artifactId>
         <version>0.1.1-SNAPSHOT</version>
     </parent>

--- a/mechtatel-logging/pom.xml
+++ b/mechtatel-logging/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.dabasan</groupId>
         <artifactId>mechtatel</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mechtatel-logging</artifactId>

--- a/mechtatel-natives-linux/pom.xml
+++ b/mechtatel-natives-linux/pom.xml
@@ -18,8 +18,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/mechtatel-natives-linux/pom.xml
+++ b/mechtatel-natives-linux/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.dabasan</groupId>
         <artifactId>mechtatel</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mechtatel-natives-linux</artifactId>

--- a/mechtatel-natives-linux/pom.xml
+++ b/mechtatel-natives-linux/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.dabasan</groupId>
+        <groupId>io.github.maeda6uiui</groupId>
         <artifactId>mechtatel</artifactId>
         <version>0.1.1-SNAPSHOT</version>
     </parent>
@@ -38,7 +38,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.dabasan</groupId>
+            <groupId>io.github.maeda6uiui</groupId>
             <artifactId>mechtatel-natives</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/mechtatel-natives-macos/pom.xml
+++ b/mechtatel-natives-macos/pom.xml
@@ -18,8 +18,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/mechtatel-natives-macos/pom.xml
+++ b/mechtatel-natives-macos/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.dabasan</groupId>
         <artifactId>mechtatel</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mechtatel-natives-macos</artifactId>

--- a/mechtatel-natives-macos/pom.xml
+++ b/mechtatel-natives-macos/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.dabasan</groupId>
+        <groupId>io.github.maeda6uiui</groupId>
         <artifactId>mechtatel</artifactId>
         <version>0.1.1-SNAPSHOT</version>
     </parent>
@@ -38,7 +38,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.dabasan</groupId>
+            <groupId>io.github.maeda6uiui</groupId>
             <artifactId>mechtatel-natives</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/mechtatel-natives-windows/pom.xml
+++ b/mechtatel-natives-windows/pom.xml
@@ -18,8 +18,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/mechtatel-natives-windows/pom.xml
+++ b/mechtatel-natives-windows/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.dabasan</groupId>
         <artifactId>mechtatel</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mechtatel-natives-windows</artifactId>

--- a/mechtatel-natives-windows/pom.xml
+++ b/mechtatel-natives-windows/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.dabasan</groupId>
+        <groupId>io.github.maeda6uiui</groupId>
         <artifactId>mechtatel</artifactId>
         <version>0.1.1-SNAPSHOT</version>
     </parent>
@@ -38,7 +38,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.dabasan</groupId>
+            <groupId>io.github.maeda6uiui</groupId>
             <artifactId>mechtatel-natives</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/mechtatel-natives/pom.xml
+++ b/mechtatel-natives/pom.xml
@@ -18,8 +18,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/mechtatel-natives/pom.xml
+++ b/mechtatel-natives/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.dabasan</groupId>
+        <groupId>io.github.maeda6uiui</groupId>
         <artifactId>mechtatel</artifactId>
         <version>0.1.1-SNAPSHOT</version>
     </parent>

--- a/mechtatel-natives/pom.xml
+++ b/mechtatel-natives/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.dabasan</groupId>
         <artifactId>mechtatel</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mechtatel-natives</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,17 +34,6 @@
         </developer>
     </developers>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-    </distributionManagement>
-
     <scm>
         <connection>scm:git:https://github.com/maeda6uiui/Mechtatel.git</connection>
         <developerConnection>scm:git:https://github.com/maeda6uiui/Mechtatel.git</developerConnection>
@@ -131,14 +120,12 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.7.0</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.7.0</version>
                     <extensions>true</extensions>
                     <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        <publishingServerId>central</publishingServerId>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -201,8 +188,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.dabasan</groupId>
+    <groupId>io.github.maeda6uiui</groupId>
     <artifactId>mechtatel</artifactId>
     <version>0.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.dabasan</groupId>
     <artifactId>mechtatel</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Mechtatel</name>
     <description>Yet unfinished Vulkan-based game engine written in Java</description>


### PR DESCRIPTION
# Overview

Introduced some changes to pom.xml and workflows so that Mechtatel can be published to the Central Portal.

- Change `groupId` to `io.github.maeda6uiui`
- Bump up version of Mechtatel
- Use central-publishing-maven-plugin
