### PR TITLE
Skip audio tests on deploy workflow

### DIFF
--- a/.github/workflows/deploy-artifacts.yml
+++ b/.github/workflows/deploy-artifacts.yml
@@ -53,4 +53,5 @@ jobs:
           mvn clean deploy \
             -Dgpg.executable=gpg \
             -Dgpg.passphrase=${{secrets.gpgPassphrase}} \
-            -Dgpg.pinentry-mode=loopback
+            -Dgpg.pinentry-mode=loopback \
+            -Dskip.audio.tests=true

--- a/mechtatel-audio/pom.xml
+++ b/mechtatel-audio/pom.xml
@@ -15,6 +15,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <skip.audio.tests>false</skip.audio.tests>
     </properties>
 
     <build>
@@ -38,6 +39,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${skip.audio.tests}</skipTests>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
# Overview

Tests in mechtatel-audio module can't be executed without major tweaks to the runner, so just skip them in the deploy workflow.
