### PR TITLE
Revert deletion of AppInfo

### DIFF
--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/AppInfo.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/AppInfo.java
@@ -1,0 +1,14 @@
+package com.github.maeda6uiui.mechtatel.core;
+
+/**
+ * Application info
+ *
+ * @author maeda6uiui
+ */
+@Deprecated
+public class AppInfo {
+    public static final String NAME = "Mechtatel";
+    public static final int MAJOR_VERSION = 0;
+    public static final int MINOR_VERSION = 0;
+    public static final int PATCH_VERSION = 1;
+}


### PR DESCRIPTION
# Overview

This PR reverts deletion of AppInfo, deleted in the following PR, to assure that the next release is a minor update.
AppInfo is marked as deprecated.

- #63 
