### PR TITLE
Delete temporary files for native libraries on next startup

### DIFF
--- a/mechtatel-audio-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/linux/NativeExtractor.java
+++ b/mechtatel-audio-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/linux/NativeExtractor.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 public class NativeExtractor implements INativeExtractor {
     @Override
     public File extractLibAudioPlayer() throws IOException {
-        return MttResourceFileUtils.extractFile(this.getClass(), "/Bin/libaudioplayer.so");
+        return MttResourceFileUtils.extractFile(
+                this.getClass(), "/Bin/libaudioplayer.so", "mttaudionatives", false);
     }
 }

--- a/mechtatel-audio-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/windows/NativeExtractor.java
+++ b/mechtatel-audio-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/windows/NativeExtractor.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 public class NativeExtractor implements INativeExtractor {
     @Override
     public File extractLibAudioPlayer() throws IOException {
-        return MttResourceFileUtils.extractFile(this.getClass(), "/Bin/audioplayer.dll");
+        return MttResourceFileUtils.extractFile(
+                this.getClass(), "/Bin/audioplayer.dll", "mttaudionatives", false);
     }
 }

--- a/mechtatel-audio/pom.xml
+++ b/mechtatel-audio/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>${mechtatel.audio.natives}</artifactId>
             <version>${parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.maeda6uiui</groupId>
+            <artifactId>mechtatel-common-utils</artifactId>
+            <version>${parent.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/mechtatel-audio/pom.xml
+++ b/mechtatel-audio/pom.xml
@@ -80,5 +80,11 @@
             <version>5.12.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.maeda6uiui</groupId>
+            <artifactId>mechtatel-logging</artifactId>
+            <version>${parent.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/mechtatel-audio/src/main/java/com/github/maeda6uiui/mechtatel/audio/MttAudio.java
+++ b/mechtatel-audio/src/main/java/com/github/maeda6uiui/mechtatel/audio/MttAudio.java
@@ -1,8 +1,12 @@
 package com.github.maeda6uiui.mechtatel.audio;
 
+import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.sun.jna.Pointer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -12,6 +16,8 @@ import java.nio.file.Paths;
  * @author maeda6uiui
  */
 public class MttAudio {
+    private static final Logger logger = LoggerFactory.getLogger(MttAudio.class);
+
     private String playerId;
 
     private String pointerToString(Pointer p) {
@@ -23,6 +29,12 @@ public class MttAudio {
     public MttAudio(String filepath) throws FileNotFoundException {
         if (!Files.exists(Paths.get(filepath))) {
             throw new FileNotFoundException(filepath);
+        }
+
+        try {
+            MttResourceFileUtils.deleteTemporaryFiles("mttaudionatives", false);
+        } catch (IOException e) {
+            logger.warn("Failed to delete temporary files", e);
         }
 
         playerId = this.pointerToString(IAudioPlayer.INSTANCE.spawn_audio_player_thread(filepath));

--- a/mechtatel-audio/src/main/java/com/github/maeda6uiui/mechtatel/audio/MttAudio.java
+++ b/mechtatel-audio/src/main/java/com/github/maeda6uiui/mechtatel/audio/MttAudio.java
@@ -1,12 +1,10 @@
 package com.github.maeda6uiui.mechtatel.audio;
 
-import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.sun.jna.Pointer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -29,12 +27,6 @@ public class MttAudio {
     public MttAudio(String filepath) throws FileNotFoundException {
         if (!Files.exists(Paths.get(filepath))) {
             throw new FileNotFoundException(filepath);
-        }
-
-        try {
-            MttResourceFileUtils.deleteTemporaryFiles("mttaudionatives", false);
-        } catch (IOException e) {
-            logger.warn("Failed to delete temporary files", e);
         }
 
         playerId = this.pointerToString(IAudioPlayer.INSTANCE.spawn_audio_player_thread(filepath));

--- a/mechtatel-audio/src/main/java/com/github/maeda6uiui/mechtatel/audio/MttAudio.java
+++ b/mechtatel-audio/src/main/java/com/github/maeda6uiui/mechtatel/audio/MttAudio.java
@@ -1,8 +1,6 @@
 package com.github.maeda6uiui.mechtatel.audio;
 
 import com.sun.jna.Pointer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.nio.file.Files;
@@ -14,8 +12,6 @@ import java.nio.file.Paths;
  * @author maeda6uiui
  */
 public class MttAudio {
-    private static final Logger logger = LoggerFactory.getLogger(MttAudio.class);
-
     private String playerId;
 
     private String pointerToString(Pointer p) {

--- a/mechtatel-audio/src/main/java/com/github/maeda6uiui/mechtatel/audio/NativeLoader.java
+++ b/mechtatel-audio/src/main/java/com/github/maeda6uiui/mechtatel/audio/NativeLoader.java
@@ -2,8 +2,11 @@ package com.github.maeda6uiui.mechtatel.audio;
 
 import com.github.maeda6uiui.mechtatel.audio.natives.INativeExtractor;
 import com.github.maeda6uiui.mechtatel.audio.natives.NativeExtractorFactory;
+import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,6 +18,8 @@ import java.lang.reflect.InvocationTargetException;
  * @author maeda6uiui
  */
 public class NativeLoader {
+    private static final Logger logger = LoggerFactory.getLogger(NativeLoader.class);
+
     public static IAudioPlayer load() {
         String platform;
         if (Platform.isWindows()) {
@@ -23,6 +28,12 @@ public class NativeLoader {
             platform = "linux";
         } else {
             throw new RuntimeException("Unsupported platform");
+        }
+
+        try {
+            MttResourceFileUtils.deleteTemporaryFiles("mttaudionatives", false);
+        } catch (IOException e) {
+            logger.warn("Failed to delete temporary files", e);
         }
 
         File libFile;

--- a/mechtatel-audio/src/main/java/module-info.java
+++ b/mechtatel-audio/src/main/java/module-info.java
@@ -1,4 +1,6 @@
 module com.github.maeda6uiui.mechtatel.audio {
     requires com.sun.jna;
     requires com.github.maeda6uiui.mechtatel.audio.natives;
+    requires org.slf4j;
+    requires com.github.maeda6uiui.mechtatel.common.utils;
 }

--- a/mechtatel-common-utils/pom.xml
+++ b/mechtatel-common-utils/pom.xml
@@ -17,4 +17,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/mechtatel-common-utils/src/main/java/com/github/maeda6uiui/mechtatel/common/utils/MttResourceFileUtils.java
+++ b/mechtatel-common-utils/src/main/java/com/github/maeda6uiui/mechtatel/common/utils/MttResourceFileUtils.java
@@ -1,8 +1,10 @@
 package com.github.maeda6uiui.mechtatel.common.utils;
 
+import org.apache.commons.io.FileUtils;
+
 import java.io.*;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.*;
+import java.util.ArrayList;
 import java.util.Objects;
 
 /**
@@ -89,5 +91,29 @@ public class MttResourceFileUtils {
     public static void loadNativeLib(Class<?> clazz, String filepath) throws IOException {
         File tempFile = extractFile(clazz, filepath, "mttnatives", false);
         System.load(tempFile.getAbsolutePath());
+    }
+
+    /**
+     * Deletes temporary files that have a prefix specified.
+     *
+     * @param prefix            Prefix for the temporary files
+     * @param deleteDirectories Deletes directories as well if true
+     * @throws IOException If it fails to enumerate files or to delete them
+     */
+    public static void deleteTemporaryFiles(String prefix, boolean deleteDirectories) throws IOException {
+        Path tempRoot = Paths.get(System.getProperty("java.io.tmpdir"));
+
+        var tempFilePaths = new ArrayList<Path>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(tempRoot, prefix + "*")) {
+            stream.forEach(tempFilePaths::add);
+        }
+
+        for (var path : tempFilePaths) {
+            if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS) && deleteDirectories) {
+                FileUtils.deleteDirectory(path.toFile());
+            } else if (Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+                Files.delete(path);
+            }
+        }
     }
 }

--- a/mechtatel-common-utils/src/main/java/com/github/maeda6uiui/mechtatel/common/utils/MttResourceFileUtils.java
+++ b/mechtatel-common-utils/src/main/java/com/github/maeda6uiui/mechtatel/common/utils/MttResourceFileUtils.java
@@ -14,15 +14,20 @@ public class MttResourceFileUtils {
     /**
      * Extracts a file from a JAR and writes it out to a temporary file.
      *
-     * @param clazz    Class to call {@link Class#getResourceAsStream(String)}
-     * @param filepath Filepath of the file
+     * @param clazz          Class to call {@link Class#getResourceAsStream(String)}
+     * @param filepath       Filepath of the file
+     * @param tempFilePrefix Prefix for the temporary file
+     * @param deleteOnExit   Deletes the temporary file on exit if true
      * @return Temporary file representing the extracted file
      * @throws IOException If it fails to extract the file
      */
-    public static File extractFile(Class<?> clazz, String filepath) throws IOException {
+    public static File extractFile(
+            Class<?> clazz, String filepath, String tempFilePrefix, boolean deleteOnExit) throws IOException {
         try (var bis = new BufferedInputStream(Objects.requireNonNull(clazz.getResourceAsStream(filepath)))) {
-            File tempFile = File.createTempFile("mtt", ".tmp");
-            tempFile.deleteOnExit();
+            File tempFile = File.createTempFile(tempFilePrefix, ".tmp");
+            if (deleteOnExit) {
+                tempFile.deleteOnExit();
+            }
 
             try (var bos = new BufferedOutputStream(new FileOutputStream(tempFile))) {
                 bis.transferTo(bos);
@@ -30,6 +35,18 @@ public class MttResourceFileUtils {
 
             return tempFile;
         }
+    }
+
+    /**
+     * Extracts a file from a JAR and writes it out to a temporary file.
+     *
+     * @param clazz    Class to call {@link Class#getResourceAsStream(String)}
+     * @param filepath Filepath of the file
+     * @return Temporary file representing the extracted file
+     * @throws IOException If it fails to extract the file
+     */
+    public static File extractFile(Class<?> clazz, String filepath) throws IOException {
+        return extractFile(clazz, filepath, "mtt", true);
     }
 
     /**
@@ -59,13 +76,18 @@ public class MttResourceFileUtils {
 
     /**
      * Loads a native library contained in a JAR.
+     * This method first extracts the native library from inside a JAR to a temporary file,
+     * and then loads it with {@link System#load(String)}.
+     * This method does not delete the temporary file because {@link File#deleteOnExit()} does not work
+     * on Windows probably because Windows still locks the DLL file even at the moment of JVM shutdown.
+     * The temporary file is created with a prefix of "mttnatives" under the OS-dependent temp directory.
      *
      * @param clazz    Class to call {@link Class#getResourceAsStream(String)}
      * @param filepath Filepath of the native library
      * @throws IOException If it fails to extract the file
      */
     public static void loadNativeLib(Class<?> clazz, String filepath) throws IOException {
-        File tempFile = extractFile(clazz, filepath);
+        File tempFile = extractFile(clazz, filepath, "mttnatives", false);
         System.load(tempFile.getAbsolutePath());
     }
 }

--- a/mechtatel-common-utils/src/main/java/module-info.java
+++ b/mechtatel-common-utils/src/main/java/module-info.java
@@ -1,3 +1,4 @@
 module com.github.maeda6uiui.mechtatel.common.utils {
+    requires org.apache.commons.io;
     exports com.github.maeda6uiui.mechtatel.common.utils;
 }

--- a/mechtatel-core/pom.xml
+++ b/mechtatel-core/pom.xml
@@ -152,6 +152,11 @@
             <artifactId>${mechtatel.natives}</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.maeda6uiui</groupId>
+            <artifactId>mechtatel-common-utils</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>io.github.maeda6uiui</groupId>

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/Mechtatel.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/Mechtatel.java
@@ -1,5 +1,6 @@
 package com.github.maeda6uiui.mechtatel.core;
 
+import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.github.maeda6uiui.mechtatel.core.physics.MttDefaultPhysicsSpace;
 import com.github.maeda6uiui.mechtatel.core.screen.texture.MttTexture;
 import com.github.maeda6uiui.mechtatel.core.vulkan.MttVulkanInstance;
@@ -69,6 +70,13 @@ public class Mechtatel implements IMechtatelWindowEventHandlers {
         alcMakeContextCurrent(alcContext);
         AL.createCapabilities(deviceCaps);
         //==========
+
+        //Delete previously created temporary files for native libraries
+        try {
+            MttResourceFileUtils.deleteTemporaryFiles("mttnatives", true);
+        } catch (IOException e) {
+            logger.warn("Failed to delete temporary files", e);
+        }
 
         //Load native libraries
         IMttNativeLoader nativeLoader;

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MechtatelHeadless.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MechtatelHeadless.java
@@ -1,5 +1,6 @@
 package com.github.maeda6uiui.mechtatel.core;
 
+import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.github.maeda6uiui.mechtatel.core.physics.MttDefaultPhysicsSpace;
 import com.github.maeda6uiui.mechtatel.core.screen.texture.MttTexture;
 import com.github.maeda6uiui.mechtatel.core.vulkan.MttVulkanInstance;
@@ -63,6 +64,13 @@ public class MechtatelHeadless implements IMechtatelHeadlessEventHandlers {
             AL.createCapabilities(deviceCaps);
         }
         //==========
+
+        //Delete previously created temporary files for native libraries
+        try {
+            MttResourceFileUtils.deleteTemporaryFiles("mttnatives", true);
+        } catch (IOException e) {
+            logger.warn("Failed to delete temporary files", e);
+        }
 
         //Load native libraries
         IMttNativeLoader nativeLoader;

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/shader/slang/MttSlangcLoader.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/shader/slang/MttSlangcLoader.java
@@ -4,14 +4,14 @@ import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
 import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderFactory;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Native library loader for the Slang compiler
@@ -31,28 +31,10 @@ class MttSlangcLoader {
             throw new RuntimeException("Unsupported platform");
         }
 
-        final String tmpDirPrefix = "mttnatives";
-
-        //Delete previously created temporary directories
-        Path tempRoot = Paths.get(System.getProperty("java.io.tmpdir"));
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(tempRoot, tmpDirPrefix + "*")) {
-            stream.forEach(p -> {
-                if (Files.isDirectory(p, LinkOption.NOFOLLOW_LINKS) && p.startsWith(tempRoot)) {
-                    try {
-                        FileUtils.deleteDirectory(p.toFile());
-                    } catch (IOException e) {
-                        logger.warn("Failed to delete temporary directory", e);
-                    }
-                }
-            });
-        } catch (IOException e) {
-            logger.warn("Failed to delete temporary directory", e);
-        }
-
         //Create a temporary directory to extract native libs into
         Path tempDir;
         try {
-            tempDir = Files.createTempDirectory(tmpDirPrefix);
+            tempDir = Files.createTempDirectory("mttnatives");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/mechtatel-core/src/main/java/module-info.java
+++ b/mechtatel-core/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module com.github.maeda6uiui.mechtatel.core {
     requires com.github.maeda6uiui.mechtatel.natives;
     requires com.sun.jna;
     requires org.apache.commons.io;
+    requires com.github.maeda6uiui.mechtatel.common.utils;
 
     exports com.github.maeda6uiui.mechtatel.core;
     exports com.github.maeda6uiui.mechtatel.core.fseffect;


### PR DESCRIPTION
# Overview

Deletes temporary files (and directories) for native libraries on the next startup of the Mechtatel engine.

Current implementation relies on the `Files.deleteOnExit` method, but it particularly fails to delete files on Windows if it's a DLL file loaded with `System.load`.
It seems that the DLL files are locked even at the moment of JVM shutdown.
To circumvent this behavior, new implementation deletes temporary files created in the last execution, leaving the ones of the current execution untouched.
