### PR TITLE
Improve loading of native libraries

### DIFF
--- a/mechtatel-audio-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/linux/MttNativeLoader.java
+++ b/mechtatel-audio-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/linux/MttNativeLoader.java
@@ -1,0 +1,24 @@
+package com.github.maeda6uiui.mechtatel.audio.natives.linux;
+
+import com.github.maeda6uiui.mechtatel.audio.natives.MttNativeLoaderBase;
+import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Native library loader for Linux
+ *
+ * @author maeda6uiui
+ */
+public class MttNativeLoader extends MttNativeLoaderBase {
+    @Override
+    public File extractLibAudioPlayer() throws IOException {
+        return MttResourceFileUtils.extractFile(
+                this.getClass(),
+                "/Bin/libaudioplayer.so",
+                TEMP_FILENAME_PREFIX,
+                false
+        );
+    }
+}

--- a/mechtatel-audio-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/linux/NativeExtractor.java
+++ b/mechtatel-audio-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/linux/NativeExtractor.java
@@ -11,6 +11,7 @@ import java.io.IOException;
  *
  * @author maeda6uiui
  */
+@Deprecated
 public class NativeExtractor implements INativeExtractor {
     @Override
     public File extractLibAudioPlayer() throws IOException {

--- a/mechtatel-audio-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/windows/MttNativeLoader.java
+++ b/mechtatel-audio-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/windows/MttNativeLoader.java
@@ -1,0 +1,24 @@
+package com.github.maeda6uiui.mechtatel.audio.natives.windows;
+
+import com.github.maeda6uiui.mechtatel.audio.natives.MttNativeLoaderBase;
+import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Native library loader for Windows
+ *
+ * @author maeda6uiui
+ */
+public class MttNativeLoader extends MttNativeLoaderBase {
+    @Override
+    public File extractLibAudioPlayer() throws IOException {
+        return MttResourceFileUtils.extractFile(
+                this.getClass(),
+                "/Bin/audioplayer.dll",
+                TEMP_FILENAME_PREFIX,
+                false
+        );
+    }
+}

--- a/mechtatel-audio-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/windows/NativeExtractor.java
+++ b/mechtatel-audio-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/windows/NativeExtractor.java
@@ -11,6 +11,7 @@ import java.io.IOException;
  *
  * @author maeda6uiui
  */
+@Deprecated
 public class NativeExtractor implements INativeExtractor {
     @Override
     public File extractLibAudioPlayer() throws IOException {

--- a/mechtatel-audio-natives/pom.xml
+++ b/mechtatel-audio-natives/pom.xml
@@ -42,4 +42,12 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.maeda6uiui</groupId>
+            <artifactId>mechtatel-common-utils</artifactId>
+            <version>${parent.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/mechtatel-audio-natives/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/INativeExtractor.java
+++ b/mechtatel-audio-natives/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/INativeExtractor.java
@@ -8,6 +8,7 @@ import java.io.IOException;
  *
  * @author maeda6uiui
  */
+@Deprecated
 public interface INativeExtractor {
     File extractLibAudioPlayer() throws IOException;
 }

--- a/mechtatel-audio-natives/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/MttNativeLoaderBase.java
+++ b/mechtatel-audio-natives/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/MttNativeLoaderBase.java
@@ -1,0 +1,29 @@
+package com.github.maeda6uiui.mechtatel.audio.natives;
+
+import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Base class for native library loader
+ *
+ * @author maeda6uiui
+ */
+public abstract class MttNativeLoaderBase {
+    private static final Logger logger = LoggerFactory.getLogger(MttNativeLoaderBase.class);
+    protected static final String TEMP_FILENAME_PREFIX = "mttaudionatives";
+
+    static {
+        //Delete previously created temporary files and directories
+        try {
+            MttResourceFileUtils.deleteTemporaryFiles(TEMP_FILENAME_PREFIX, true);
+        } catch (IOException e) {
+            logger.warn("Failed to delete temporary files", e);
+        }
+    }
+
+    public abstract File extractLibAudioPlayer() throws IOException;
+}

--- a/mechtatel-audio-natives/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/MttNativeLoaderFactory.java
+++ b/mechtatel-audio-natives/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/MttNativeLoaderFactory.java
@@ -1,0 +1,27 @@
+package com.github.maeda6uiui.mechtatel.audio.natives;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Factory for native loader
+ *
+ * @author maeda6uiui
+ */
+public class MttNativeLoaderFactory {
+    private static final String NATIVE_EXTRACTOR_CLASS_NAME = "MttNativeLoader";
+    private static final String WINDOWS_PACKAGE_PATH = "com.github.maeda6uiui.mechtatel.audio.natives.windows";
+    private static final String LINUX_PACKAGE_PATH = "com.github.maeda6uiui.mechtatel.audio.natives.linux";
+
+    public static MttNativeLoaderBase createNativeExtractor(String platform)
+            throws ClassNotFoundException, NoSuchMethodException,
+            InstantiationException, IllegalAccessException, InvocationTargetException {
+        String className = switch (platform) {
+            case "windows" -> WINDOWS_PACKAGE_PATH + "." + NATIVE_EXTRACTOR_CLASS_NAME;
+            case "linux" -> LINUX_PACKAGE_PATH + "." + NATIVE_EXTRACTOR_CLASS_NAME;
+            default -> throw new IllegalArgumentException("Unsupported platform: " + platform);
+        };
+
+        Class<?> clazz = Class.forName(className);
+        return (MttNativeLoaderBase) clazz.getDeclaredConstructor().newInstance();
+    }
+}

--- a/mechtatel-audio-natives/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/NativeExtractorFactory.java
+++ b/mechtatel-audio-natives/src/main/java/com/github/maeda6uiui/mechtatel/audio/natives/NativeExtractorFactory.java
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
  *
  * @author maeda6uiui
  */
+@Deprecated
 public class NativeExtractorFactory {
     private static final String NATIVE_EXTRACTOR_CLASS_NAME = "NativeExtractor";
     private static final String WINDOWS_PACKAGE_PATH = "com.github.maeda6uiui.mechtatel.audio.natives.windows";

--- a/mechtatel-audio-natives/src/main/java/module-info.java
+++ b/mechtatel-audio-natives/src/main/java/module-info.java
@@ -1,3 +1,5 @@
 module com.github.maeda6uiui.mechtatel.audio.natives {
+    requires org.slf4j;
+    requires com.github.maeda6uiui.mechtatel.common.utils;
     exports com.github.maeda6uiui.mechtatel.audio.natives;
 }

--- a/mechtatel-audio/src/main/java/com/github/maeda6uiui/mechtatel/audio/NativeLoader.java
+++ b/mechtatel-audio/src/main/java/com/github/maeda6uiui/mechtatel/audio/NativeLoader.java
@@ -1,12 +1,9 @@
 package com.github.maeda6uiui.mechtatel.audio;
 
-import com.github.maeda6uiui.mechtatel.audio.natives.INativeExtractor;
-import com.github.maeda6uiui.mechtatel.audio.natives.NativeExtractorFactory;
-import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
+import com.github.maeda6uiui.mechtatel.audio.natives.MttNativeLoaderBase;
+import com.github.maeda6uiui.mechtatel.audio.natives.MttNativeLoaderFactory;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,8 +15,6 @@ import java.lang.reflect.InvocationTargetException;
  * @author maeda6uiui
  */
 public class NativeLoader {
-    private static final Logger logger = LoggerFactory.getLogger(NativeLoader.class);
-
     public static IAudioPlayer load() {
         String platform;
         if (Platform.isWindows()) {
@@ -30,16 +25,10 @@ public class NativeLoader {
             throw new RuntimeException("Unsupported platform");
         }
 
-        try {
-            MttResourceFileUtils.deleteTemporaryFiles("mttaudionatives", false);
-        } catch (IOException e) {
-            logger.warn("Failed to delete temporary files", e);
-        }
-
         File libFile;
         try {
-            INativeExtractor extractor = NativeExtractorFactory.createNativeExtractor(platform);
-            libFile = extractor.extractLibAudioPlayer();
+            MttNativeLoaderBase loader = MttNativeLoaderFactory.createNativeExtractor(platform);
+            libFile = loader.extractLibAudioPlayer();
         } catch (
                 ClassNotFoundException
                 | NoSuchMethodException

--- a/mechtatel-common-utils/src/main/java/com/github/maeda6uiui/mechtatel/common/utils/MttResourceFileUtils.java
+++ b/mechtatel-common-utils/src/main/java/com/github/maeda6uiui/mechtatel/common/utils/MttResourceFileUtils.java
@@ -80,6 +80,24 @@ public class MttResourceFileUtils {
      * Loads a native library contained in a JAR.
      * This method first extracts the native library from inside a JAR to a temporary file,
      * and then loads it with {@link System#load(String)}.
+     * The temporary file is created under the OS-dependent temp directory.
+     * Note that delete-on-exit method does not work on Windows
+     * because it seems that the DLL file is locked even at the moment of JVM shutdown.
+     *
+     * @param clazz    Class to call {@link Class#getResourceAsStream(String)}
+     * @param filepath Filepath of the native library
+     * @throws IOException If it fails to extract the file
+     */
+    public static void loadNativeLib(
+            Class<?> clazz, String filepath, String tempFilePrefix, boolean deleteOnExit) throws IOException {
+        File tempFile = extractFile(clazz, filepath, tempFilePrefix, deleteOnExit);
+        System.load(tempFile.getAbsolutePath());
+    }
+
+    /**
+     * Loads a native library contained in a JAR.
+     * This method first extracts the native library from inside a JAR to a temporary file,
+     * and then loads it with {@link System#load(String)}.
      * This method does not delete the temporary file because {@link File#deleteOnExit()} does not work
      * on Windows probably because Windows still locks the DLL file even at the moment of JVM shutdown.
      * The temporary file is created with a prefix of "mttnatives" under the OS-dependent temp directory.
@@ -88,9 +106,9 @@ public class MttResourceFileUtils {
      * @param filepath Filepath of the native library
      * @throws IOException If it fails to extract the file
      */
+    @Deprecated
     public static void loadNativeLib(Class<?> clazz, String filepath) throws IOException {
-        File tempFile = extractFile(clazz, filepath, "mttnatives", false);
-        System.load(tempFile.getAbsolutePath());
+        loadNativeLib(clazz, filepath, "mttnatives", false);
     }
 
     /**

--- a/mechtatel-core/pom.xml
+++ b/mechtatel-core/pom.xml
@@ -152,11 +152,6 @@
             <artifactId>${mechtatel.natives}</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.github.maeda6uiui</groupId>
-            <artifactId>mechtatel-common-utils</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>io.github.maeda6uiui</groupId>

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/Mechtatel.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/Mechtatel.java
@@ -1,11 +1,10 @@
 package com.github.maeda6uiui.mechtatel.core;
 
-import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.github.maeda6uiui.mechtatel.core.physics.MttDefaultPhysicsSpace;
 import com.github.maeda6uiui.mechtatel.core.screen.texture.MttTexture;
 import com.github.maeda6uiui.mechtatel.core.vulkan.MttVulkanInstance;
-import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
-import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderFactory;
+import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderBase;
+import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderFactory2;
 import com.jme3.bullet.PhysicsSpace;
 import org.lwjgl.openal.AL;
 import org.lwjgl.openal.ALC;
@@ -71,17 +70,10 @@ public class Mechtatel implements IMechtatelWindowEventHandlers {
         AL.createCapabilities(deviceCaps);
         //==========
 
-        //Delete previously created temporary files for native libraries
-        try {
-            MttResourceFileUtils.deleteTemporaryFiles("mttnatives", true);
-        } catch (IOException e) {
-            logger.warn("Failed to delete temporary files", e);
-        }
-
         //Load native libraries
-        IMttNativeLoader nativeLoader;
+        MttNativeLoaderBase nativeLoader;
         try {
-            nativeLoader = MttNativeLoaderFactory.createNativeLoader(PlatformInfo.PLATFORM);
+            nativeLoader = MttNativeLoaderFactory2.createNativeLoader(PlatformInfo.PLATFORM);
         } catch (ClassNotFoundException
                  | NoSuchMethodException
                  | InstantiationException

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MechtatelHeadless.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/MechtatelHeadless.java
@@ -1,11 +1,10 @@
 package com.github.maeda6uiui.mechtatel.core;
 
-import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.github.maeda6uiui.mechtatel.core.physics.MttDefaultPhysicsSpace;
 import com.github.maeda6uiui.mechtatel.core.screen.texture.MttTexture;
 import com.github.maeda6uiui.mechtatel.core.vulkan.MttVulkanInstance;
-import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
-import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderFactory;
+import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderBase;
+import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderFactory2;
 import com.jme3.bullet.PhysicsSpace;
 import org.lwjgl.openal.AL;
 import org.lwjgl.openal.ALC;
@@ -65,17 +64,10 @@ public class MechtatelHeadless implements IMechtatelHeadlessEventHandlers {
         }
         //==========
 
-        //Delete previously created temporary files for native libraries
-        try {
-            MttResourceFileUtils.deleteTemporaryFiles("mttnatives", true);
-        } catch (IOException e) {
-            logger.warn("Failed to delete temporary files", e);
-        }
-
         //Load native libraries
-        IMttNativeLoader nativeLoader;
+        MttNativeLoaderBase nativeLoader;
         try {
-            nativeLoader = MttNativeLoaderFactory.createNativeLoader(PlatformInfo.PLATFORM);
+            nativeLoader = MttNativeLoaderFactory2.createNativeLoader(PlatformInfo.PLATFORM);
         } catch (ClassNotFoundException
                  | NoSuchMethodException
                  | InstantiationException

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/shader/slang/MttSlangcLoader.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/shader/slang/MttSlangcLoader.java
@@ -1,17 +1,13 @@
 package com.github.maeda6uiui.mechtatel.core.vulkan.shader.slang;
 
-import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
-import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderFactory;
+import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderBase;
+import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderFactory2;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 /**
  * Native library loader for the Slang compiler
@@ -19,8 +15,6 @@ import java.nio.file.Path;
  * @author maeda6uiui
  */
 class MttSlangcLoader {
-    private static final Logger logger = LoggerFactory.getLogger(MttSlangcLoader.class);
-
     public static IMttSlangc load() {
         String platform;
         if (Platform.isWindows()) {
@@ -31,21 +25,13 @@ class MttSlangcLoader {
             throw new RuntimeException("Unsupported platform");
         }
 
-        //Create a temporary directory to extract native libs into
-        Path tempDir;
-        try {
-            tempDir = Files.createTempDirectory("mttnatives");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
         //Extract native libs
         File slangLibFile;
         File mttslangcLibFile;
         try {
-            IMttNativeLoader loader = MttNativeLoaderFactory.createNativeLoader(platform);
-            slangLibFile = loader.extractLibSlang(tempDir);
-            mttslangcLibFile = loader.extractLibMttSlangc(tempDir);
+            MttNativeLoaderBase loader = MttNativeLoaderFactory2.createNativeLoader(platform);
+            slangLibFile = loader.extractLibSlang();
+            mttslangcLibFile = loader.extractLibMttSlangc();
         } catch (
                 ClassNotFoundException
                 | NoSuchMethodException

--- a/mechtatel-core/src/main/java/module-info.java
+++ b/mechtatel-core/src/main/java/module-info.java
@@ -17,7 +17,6 @@ module com.github.maeda6uiui.mechtatel.core {
     requires com.github.maeda6uiui.mechtatel.natives;
     requires com.sun.jna;
     requires org.apache.commons.io;
-    requires com.github.maeda6uiui.mechtatel.common.utils;
 
     exports com.github.maeda6uiui.mechtatel.core;
     exports com.github.maeda6uiui.mechtatel.core.fseffect;

--- a/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader.java
+++ b/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader.java
@@ -2,6 +2,7 @@ package com.github.maeda6uiui.mechtatel.natives.linux;
 
 import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
+import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderBase;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,7 +13,7 @@ import java.nio.file.Path;
  *
  * @author maeda6uiui
  */
-public class MttNativeLoader implements IMttNativeLoader {
+public class MttNativeLoader extends MttNativeLoaderBase implements IMttNativeLoader {
     @Override
     public void loadLibbulletjme() throws IOException {
         MttResourceFileUtils.loadNativeLib(this.getClass(), "/Bin/Linux64ReleaseSp_libbulletjme.so");

--- a/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader.java
+++ b/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
  *
  * @author maeda6uiui
  */
+@Deprecated
 public class MttNativeLoader implements IMttNativeLoader {
     @Override
     public void loadLibbulletjme() throws IOException {

--- a/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader.java
+++ b/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader.java
@@ -2,7 +2,6 @@ package com.github.maeda6uiui.mechtatel.natives.linux;
 
 import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
-import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderBase;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,19 +12,13 @@ import java.nio.file.Path;
  *
  * @author maeda6uiui
  */
-public class MttNativeLoader extends MttNativeLoaderBase implements IMttNativeLoader {
+public class MttNativeLoader implements IMttNativeLoader {
     @Override
     public void loadLibbulletjme() throws IOException {
-        MttResourceFileUtils.loadNativeLib(
-                this.getClass(),
-                "/Bin/Linux64ReleaseSp_libbulletjme.so",
-                "mttnatives",
-                false
-        );
+        MttResourceFileUtils.loadNativeLib(this.getClass(), "/Bin/Linux64ReleaseSp_libbulletjme.so");
     }
 
     @Override
-    @Deprecated
     public File extractLibMttSlangc() throws IOException {
         return MttResourceFileUtils.extractFile(this.getClass(), "/Bin/libmttslangc.so");
     }
@@ -41,7 +34,6 @@ public class MttNativeLoader extends MttNativeLoaderBase implements IMttNativeLo
     }
 
     @Override
-    @Deprecated
     public void loadLibSlang() throws IOException {
         MttResourceFileUtils.loadNativeLib(this.getClass(), "/Bin/libslang.so");
     }

--- a/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader.java
+++ b/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader.java
@@ -16,10 +16,16 @@ import java.nio.file.Path;
 public class MttNativeLoader extends MttNativeLoaderBase implements IMttNativeLoader {
     @Override
     public void loadLibbulletjme() throws IOException {
-        MttResourceFileUtils.loadNativeLib(this.getClass(), "/Bin/Linux64ReleaseSp_libbulletjme.so");
+        MttResourceFileUtils.loadNativeLib(
+                this.getClass(),
+                "/Bin/Linux64ReleaseSp_libbulletjme.so",
+                "mttnatives",
+                false
+        );
     }
 
     @Override
+    @Deprecated
     public File extractLibMttSlangc() throws IOException {
         return MttResourceFileUtils.extractFile(this.getClass(), "/Bin/libmttslangc.so");
     }
@@ -35,6 +41,7 @@ public class MttNativeLoader extends MttNativeLoaderBase implements IMttNativeLo
     }
 
     @Override
+    @Deprecated
     public void loadLibSlang() throws IOException {
         MttResourceFileUtils.loadNativeLib(this.getClass(), "/Bin/libslang.so");
     }

--- a/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader2.java
+++ b/mechtatel-natives-linux/src/main/java/com/github/maeda6uiui/mechtatel/natives/linux/MttNativeLoader2.java
@@ -1,0 +1,36 @@
+package com.github.maeda6uiui.mechtatel.natives.linux;
+
+import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
+import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderBase;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Loads native libraries for Linux
+ *
+ * @author maeda6uiui
+ */
+public class MttNativeLoader2 extends MttNativeLoaderBase {
+    @Override
+    public void loadLibbulletjme() throws IOException {
+        MttResourceFileUtils.loadNativeLib(
+                this.getClass(),
+                "/Bin/Linux64ReleaseSp_libbulletjme.so",
+                TEMP_FILENAME_PREFIX,
+                false
+        );
+    }
+
+    @Override
+    public File extractLibMttSlangc() throws IOException {
+        return MttResourceFileUtils.extractFileIntoDir(
+                this.getClass(), "/Bin/libmttslangc.so", this.getTempDir());
+    }
+
+    @Override
+    public File extractLibSlang() throws IOException {
+        return MttResourceFileUtils.extractFileIntoDir(
+                this.getClass(), "/Bin/libslang.so", this.getTempDir());
+    }
+}

--- a/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader.java
+++ b/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader.java
@@ -16,10 +16,16 @@ import java.nio.file.Path;
 public class MttNativeLoader extends MttNativeLoaderBase implements IMttNativeLoader {
     @Override
     public void loadLibbulletjme() throws IOException {
-        MttResourceFileUtils.loadNativeLib(this.getClass(), "/Bin/Windows64ReleaseSp_bulletjme.dll");
+        MttResourceFileUtils.loadNativeLib(
+                this.getClass(),
+                "/Bin/Windows64ReleaseSp_bulletjme.dll",
+                "mttnatives",
+                false
+        );
     }
 
     @Override
+    @Deprecated
     public File extractLibMttSlangc() throws IOException {
         return MttResourceFileUtils.extractFile(this.getClass(), "/Bin/mttslangc.dll");
     }
@@ -35,6 +41,7 @@ public class MttNativeLoader extends MttNativeLoaderBase implements IMttNativeLo
     }
 
     @Override
+    @Deprecated
     public void loadLibSlang() throws IOException {
         MttResourceFileUtils.loadNativeLib(this.getClass(), "/Bin/slang.dll");
     }

--- a/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader.java
+++ b/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
  *
  * @author maeda6uiui
  */
+@Deprecated
 public class MttNativeLoader implements IMttNativeLoader {
     @Override
     public void loadLibbulletjme() throws IOException {

--- a/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader.java
+++ b/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader.java
@@ -2,6 +2,7 @@ package com.github.maeda6uiui.mechtatel.natives.windows;
 
 import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
+import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderBase;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,7 +13,7 @@ import java.nio.file.Path;
  *
  * @author maeda6uiui
  */
-public class MttNativeLoader implements IMttNativeLoader {
+public class MttNativeLoader extends MttNativeLoaderBase implements IMttNativeLoader {
     @Override
     public void loadLibbulletjme() throws IOException {
         MttResourceFileUtils.loadNativeLib(this.getClass(), "/Bin/Windows64ReleaseSp_bulletjme.dll");

--- a/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader.java
+++ b/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader.java
@@ -2,7 +2,6 @@ package com.github.maeda6uiui.mechtatel.natives.windows;
 
 import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
 import com.github.maeda6uiui.mechtatel.natives.IMttNativeLoader;
-import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderBase;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,19 +12,13 @@ import java.nio.file.Path;
  *
  * @author maeda6uiui
  */
-public class MttNativeLoader extends MttNativeLoaderBase implements IMttNativeLoader {
+public class MttNativeLoader implements IMttNativeLoader {
     @Override
     public void loadLibbulletjme() throws IOException {
-        MttResourceFileUtils.loadNativeLib(
-                this.getClass(),
-                "/Bin/Windows64ReleaseSp_bulletjme.dll",
-                "mttnatives",
-                false
-        );
+        MttResourceFileUtils.loadNativeLib(this.getClass(), "/Bin/Windows64ReleaseSp_bulletjme.dll");
     }
 
     @Override
-    @Deprecated
     public File extractLibMttSlangc() throws IOException {
         return MttResourceFileUtils.extractFile(this.getClass(), "/Bin/mttslangc.dll");
     }
@@ -41,7 +34,6 @@ public class MttNativeLoader extends MttNativeLoaderBase implements IMttNativeLo
     }
 
     @Override
-    @Deprecated
     public void loadLibSlang() throws IOException {
         MttResourceFileUtils.loadNativeLib(this.getClass(), "/Bin/slang.dll");
     }

--- a/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader2.java
+++ b/mechtatel-natives-windows/src/main/java/com/github/maeda6uiui/mechtatel/natives/windows/MttNativeLoader2.java
@@ -1,0 +1,36 @@
+package com.github.maeda6uiui.mechtatel.natives.windows;
+
+import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
+import com.github.maeda6uiui.mechtatel.natives.MttNativeLoaderBase;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Loads native libraries for Windows
+ *
+ * @author maeda6uiui
+ */
+public class MttNativeLoader2 extends MttNativeLoaderBase {
+    @Override
+    public void loadLibbulletjme() throws IOException {
+        MttResourceFileUtils.loadNativeLib(
+                this.getClass(),
+                "/Bin/Windows64ReleaseSp_bulletjme.dll",
+                TEMP_FILENAME_PREFIX,
+                false
+        );
+    }
+
+    @Override
+    public File extractLibMttSlangc() throws IOException {
+        return MttResourceFileUtils.extractFileIntoDir(
+                this.getClass(), "/Bin/mttslangc.dll", this.getTempDir());
+    }
+
+    @Override
+    public File extractLibSlang() throws IOException {
+        return MttResourceFileUtils.extractFileIntoDir(
+                this.getClass(), "/Bin/slang.dll", this.getTempDir());
+    }
+}

--- a/mechtatel-natives/pom.xml
+++ b/mechtatel-natives/pom.xml
@@ -36,4 +36,12 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.maeda6uiui</groupId>
+            <artifactId>mechtatel-common-utils</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/IMttNativeLoader.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/IMttNativeLoader.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
  *
  * @author maeda6uiui
  */
+@Deprecated
 public interface IMttNativeLoader {
     void loadLibbulletjme() throws IOException;
 

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderBase.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderBase.java
@@ -16,21 +16,21 @@ import java.nio.file.Path;
  */
 public abstract class MttNativeLoaderBase {
     private static final Logger logger = LoggerFactory.getLogger(MttNativeLoaderBase.class);
-    private static final String TEMP_DIR_PREFIX = "mttnatives";
+    protected static final String TEMP_FILENAME_PREFIX = "mttnatives";
 
     private Path tempDir;
 
     public MttNativeLoaderBase() {
         //Delete previously created temporary files and directories
         try {
-            MttResourceFileUtils.deleteTemporaryFiles(TEMP_DIR_PREFIX, true);
+            MttResourceFileUtils.deleteTemporaryFiles(TEMP_FILENAME_PREFIX, true);
         } catch (IOException e) {
             logger.warn("Failed to delete temporary files", e);
         }
 
         //Create a new temporary directory to extract native libraries into
         try {
-            tempDir = Files.createTempDirectory(TEMP_DIR_PREFIX);
+            tempDir = Files.createTempDirectory(TEMP_FILENAME_PREFIX);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderBase.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderBase.java
@@ -1,0 +1,22 @@
+package com.github.maeda6uiui.mechtatel.natives;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Base class for native library loader
+ *
+ * @author maeda6uiui
+ */
+public abstract class MttNativeLoaderBase {
+    public MttNativeLoaderBase() {
+
+    }
+
+    public abstract void loadLibbulletjme() throws IOException;
+
+    public abstract File extractLibMttSlangc(Path tempDir) throws IOException;
+
+    public abstract File extractLibSlang(Path tempDir) throws IOException;
+}

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderBase.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderBase.java
@@ -20,14 +20,16 @@ public abstract class MttNativeLoaderBase {
 
     private Path tempDir;
 
-    public MttNativeLoaderBase() {
+    static {
         //Delete previously created temporary files and directories
         try {
             MttResourceFileUtils.deleteTemporaryFiles(TEMP_FILENAME_PREFIX, true);
         } catch (IOException e) {
             logger.warn("Failed to delete temporary files", e);
         }
+    }
 
+    public MttNativeLoaderBase() {
         //Create a new temporary directory to extract native libraries into
         try {
             tempDir = Files.createTempDirectory(TEMP_FILENAME_PREFIX);

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderBase.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderBase.java
@@ -1,7 +1,12 @@
 package com.github.maeda6uiui.mechtatel.natives;
 
+import com.github.maeda6uiui.mechtatel.common.utils.MttResourceFileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -10,13 +15,34 @@ import java.nio.file.Path;
  * @author maeda6uiui
  */
 public abstract class MttNativeLoaderBase {
-    public MttNativeLoaderBase() {
+    private static final Logger logger = LoggerFactory.getLogger(MttNativeLoaderBase.class);
+    private static final String TEMP_DIR_PREFIX = "mttnatives";
 
+    private Path tempDir;
+
+    public MttNativeLoaderBase() {
+        //Delete previously created temporary files and directories
+        try {
+            MttResourceFileUtils.deleteTemporaryFiles(TEMP_DIR_PREFIX, true);
+        } catch (IOException e) {
+            logger.warn("Failed to delete temporary files", e);
+        }
+
+        //Create a new temporary directory to extract native libraries into
+        try {
+            tempDir = Files.createTempDirectory(TEMP_DIR_PREFIX);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected Path getTempDir() {
+        return tempDir;
     }
 
     public abstract void loadLibbulletjme() throws IOException;
 
-    public abstract File extractLibMttSlangc(Path tempDir) throws IOException;
+    public abstract File extractLibMttSlangc() throws IOException;
 
-    public abstract File extractLibSlang(Path tempDir) throws IOException;
+    public abstract File extractLibSlang() throws IOException;
 }

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderFactory.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderFactory.java
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
  *
  * @author maeda6uiui
  */
+@Deprecated
 public class MttNativeLoaderFactory {
     private static final String NATIVE_LOADER_CLASS_NAME = "MttNativeLoader";
     private static final String WINDOWS_PACKAGE_PATH = "com.github.maeda6uiui.mechtatel.natives.windows";

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderFactory.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderFactory.java
@@ -12,16 +12,28 @@ public class MttNativeLoaderFactory {
     private static final String WINDOWS_PACKAGE_PATH = "com.github.maeda6uiui.mechtatel.natives.windows";
     private static final String LINUX_PACKAGE_PATH = "com.github.maeda6uiui.mechtatel.natives.linux";
 
-    public static IMttNativeLoader createNativeLoader(String platform)
-            throws ClassNotFoundException, NoSuchMethodException,
-            InstantiationException, IllegalAccessException, InvocationTargetException {
+    private static Class<?> createNativeLoaderClass(String platform) throws ClassNotFoundException {
         String className = switch (platform) {
             case "windows" -> WINDOWS_PACKAGE_PATH + "." + NATIVE_LOADER_CLASS_NAME;
             case "linux" -> LINUX_PACKAGE_PATH + "." + NATIVE_LOADER_CLASS_NAME;
             default -> throw new IllegalArgumentException("Unsupported platform: " + platform);
         };
 
-        Class<?> clazz = Class.forName(className);
+        return Class.forName(className);
+    }
+
+    @Deprecated
+    public static IMttNativeLoader createNativeLoader(String platform)
+            throws ClassNotFoundException, NoSuchMethodException,
+            InstantiationException, IllegalAccessException, InvocationTargetException {
+        Class<?> clazz = createNativeLoaderClass(platform);
         return (IMttNativeLoader) clazz.getDeclaredConstructor().newInstance();
+    }
+
+    public static MttNativeLoaderBase createNativeLoaderForPlatform(String platform)
+            throws ClassNotFoundException, NoSuchMethodException,
+            InstantiationException, IllegalAccessException, InvocationTargetException {
+        Class<?> clazz = createNativeLoaderClass(platform);
+        return (MttNativeLoaderBase) clazz.getDeclaredConstructor().newInstance();
     }
 }

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderFactory.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderFactory.java
@@ -12,28 +12,16 @@ public class MttNativeLoaderFactory {
     private static final String WINDOWS_PACKAGE_PATH = "com.github.maeda6uiui.mechtatel.natives.windows";
     private static final String LINUX_PACKAGE_PATH = "com.github.maeda6uiui.mechtatel.natives.linux";
 
-    private static Class<?> createNativeLoaderClass(String platform) throws ClassNotFoundException {
+    public static IMttNativeLoader createNativeLoader(String platform)
+            throws ClassNotFoundException, NoSuchMethodException,
+            InstantiationException, IllegalAccessException, InvocationTargetException {
         String className = switch (platform) {
             case "windows" -> WINDOWS_PACKAGE_PATH + "." + NATIVE_LOADER_CLASS_NAME;
             case "linux" -> LINUX_PACKAGE_PATH + "." + NATIVE_LOADER_CLASS_NAME;
             default -> throw new IllegalArgumentException("Unsupported platform: " + platform);
         };
 
-        return Class.forName(className);
-    }
-
-    @Deprecated
-    public static IMttNativeLoader createNativeLoader(String platform)
-            throws ClassNotFoundException, NoSuchMethodException,
-            InstantiationException, IllegalAccessException, InvocationTargetException {
-        Class<?> clazz = createNativeLoaderClass(platform);
+        Class<?> clazz = Class.forName(className);
         return (IMttNativeLoader) clazz.getDeclaredConstructor().newInstance();
-    }
-
-    public static MttNativeLoaderBase createNativeLoaderForPlatform(String platform)
-            throws ClassNotFoundException, NoSuchMethodException,
-            InstantiationException, IllegalAccessException, InvocationTargetException {
-        Class<?> clazz = createNativeLoaderClass(platform);
-        return (MttNativeLoaderBase) clazz.getDeclaredConstructor().newInstance();
     }
 }

--- a/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderFactory2.java
+++ b/mechtatel-natives/src/main/java/com/github/maeda6uiui/mechtatel/natives/MttNativeLoaderFactory2.java
@@ -1,0 +1,27 @@
+package com.github.maeda6uiui.mechtatel.natives;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Factory of native loader
+ *
+ * @author maeda6uiui
+ */
+public class MttNativeLoaderFactory2 {
+    private static final String NATIVE_LOADER_CLASS_NAME = "MttNativeLoader2";
+    private static final String WINDOWS_PACKAGE_PATH = "com.github.maeda6uiui.mechtatel.natives.windows";
+    private static final String LINUX_PACKAGE_PATH = "com.github.maeda6uiui.mechtatel.natives.linux";
+
+    public static MttNativeLoaderBase createNativeLoader(String platform)
+            throws ClassNotFoundException, NoSuchMethodException,
+            InstantiationException, IllegalAccessException, InvocationTargetException {
+        String className = switch (platform) {
+            case "windows" -> WINDOWS_PACKAGE_PATH + "." + NATIVE_LOADER_CLASS_NAME;
+            case "linux" -> LINUX_PACKAGE_PATH + "." + NATIVE_LOADER_CLASS_NAME;
+            default -> throw new IllegalArgumentException("Unsupported platform: " + platform);
+        };
+
+        Class<?> clazz = Class.forName(className);
+        return (MttNativeLoaderBase) clazz.getDeclaredConstructor().newInstance();
+    }
+}

--- a/mechtatel-natives/src/main/java/module-info.java
+++ b/mechtatel-natives/src/main/java/module-info.java
@@ -1,3 +1,5 @@
 module com.github.maeda6uiui.mechtatel.natives {
+    requires org.slf4j;
+    requires com.github.maeda6uiui.mechtatel.common.utils;
     exports com.github.maeda6uiui.mechtatel.natives;
 }


### PR DESCRIPTION
# Overview

- Change native loader to an abstract class
  - Delete previously created temporary files in a static block
  - Create a temporary directory when a native loader is instantiated
- Mark old interfaces as deprecated
