### PR TITLE
Move handling of texture allocation index to VkMttScreen

### DIFF
--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/VkMttScreen.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/VkMttScreen.java
@@ -73,34 +73,6 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
     // - PrimitiveNabor (fill)
     private static final int NUM_SCENES_TO_MERGE = 3;
 
-    private static final Map<Integer, Boolean> allocationStatus;
-
-    static {
-        allocationStatus = new HashMap<>();
-        for (int i = 0; i < GBufferNabor.MAX_NUM_TEXTURES; i++) {
-            allocationStatus.put(i, false);
-        }
-    }
-
-    public static int allocateTextureIndex() {
-        int index = -1;
-
-        for (var entry : allocationStatus.entrySet()) {
-            if (!entry.getValue()) {
-                index = entry.getKey();
-                allocationStatus.put(index, true);
-
-                break;
-            }
-        }
-
-        return index;
-    }
-
-    public static void deallocateTexture(int allocationIndex) {
-        allocationStatus.put(allocationIndex, false);
-    }
-
     private VkDevice device;
     private long commandPool;
     private VkQueue graphicsQueue;
@@ -125,6 +97,8 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
     private boolean shouldChangeExtentOnRecreate;
 
     private QuadDrawer quadDrawer;
+
+    private Map<Integer, Boolean> allocationStatus;
 
     private void createShadowMappingNaborUserDefImages(ShadowMappingNabor shadowMappingNabor) {
         shadowMappingNabor.cleanupUserDefImages();
@@ -187,6 +161,11 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
         this.shouldChangeExtentOnRecreate = createInfo.shouldChangeExtentOnRecreate;
 
         quadDrawer = new QuadDrawer(device, commandPool, graphicsQueue);
+
+        allocationStatus = new HashMap<>();
+        for (int i = 0; i < GBufferNabor.MAX_NUM_TEXTURES; i++) {
+            allocationStatus.put(i, false);
+        }
 
         MttShaderConfig shaderConfig = MttShaderConfig
                 .get()
@@ -1079,5 +1058,24 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
         }
 
         return textureDescriptorSets;
+    }
+
+    public int allocateTextureIndex() {
+        int index = -1;
+
+        for (var entry : allocationStatus.entrySet()) {
+            if (!entry.getValue()) {
+                index = entry.getKey();
+                allocationStatus.put(index, true);
+
+                break;
+            }
+        }
+
+        return index;
+    }
+
+    public void deallocateTexture(int allocationIndex) {
+        allocationStatus.put(allocationIndex, false);
     }
 }

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/VkMttScreen.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/VkMttScreen.java
@@ -31,7 +31,10 @@ import org.lwjgl.vulkan.*;
 import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static org.lwjgl.vulkan.VK10.*;
 
@@ -98,7 +101,7 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
 
     private QuadDrawer quadDrawer;
 
-    private Map<Integer, Boolean> allocationStatus;
+    private boolean[] allocationStatuses;
 
     private void createShadowMappingNaborUserDefImages(ShadowMappingNabor shadowMappingNabor) {
         shadowMappingNabor.cleanupUserDefImages();
@@ -162,9 +165,9 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
 
         quadDrawer = new QuadDrawer(device, commandPool, graphicsQueue);
 
-        allocationStatus = new HashMap<>();
-        for (int i = 0; i < GBufferNabor.MAX_NUM_TEXTURES; i++) {
-            allocationStatus.put(i, false);
+        allocationStatuses = new boolean[GBufferNabor.MAX_NUM_TEXTURES];
+        for (int i = 0; i < allocationStatuses.length; i++) {
+            allocationStatuses[i] = false;
         }
 
         MttShaderConfig shaderConfig = MttShaderConfig
@@ -1063,11 +1066,10 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
     public int allocateTextureIndex() {
         int index = -1;
 
-        for (var entry : allocationStatus.entrySet()) {
-            if (!entry.getValue()) {
-                index = entry.getKey();
-                allocationStatus.put(index, true);
-
+        for (int i = 0; i < allocationStatuses.length; i++) {
+            if (!allocationStatuses[i]) {
+                index = i;
+                allocationStatuses[i] = true;
                 break;
             }
         }
@@ -1076,6 +1078,6 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
     }
 
     public void deallocateTexture(int allocationIndex) {
-        allocationStatus.put(allocationIndex, false);
+        allocationStatuses[allocationIndex] = false;
     }
 }

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/VkMttScreen.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/VkMttScreen.java
@@ -31,10 +31,7 @@ import org.lwjgl.vulkan.*;
 import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.lwjgl.vulkan.VK10.*;
 
@@ -75,6 +72,34 @@ public class VkMttScreen implements IVkMttScreenForVkMttTexture, IVkMttScreenFor
     // - PrimitiveNabor
     // - PrimitiveNabor (fill)
     private static final int NUM_SCENES_TO_MERGE = 3;
+
+    private static final Map<Integer, Boolean> allocationStatus;
+
+    static {
+        allocationStatus = new HashMap<>();
+        for (int i = 0; i < GBufferNabor.MAX_NUM_TEXTURES; i++) {
+            allocationStatus.put(i, false);
+        }
+    }
+
+    public static int allocateTextureIndex() {
+        int index = -1;
+
+        for (var entry : allocationStatus.entrySet()) {
+            if (!entry.getValue()) {
+                index = entry.getKey();
+                allocationStatus.put(index, true);
+
+                break;
+            }
+        }
+
+        return index;
+    }
+
+    public static void deallocateTexture(int allocationIndex) {
+        allocationStatus.put(allocationIndex, false);
+    }
 
     private VkDevice device;
     private long commandPool;

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/texture/VkMttTexture.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/texture/VkMttTexture.java
@@ -16,8 +16,6 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.lwjgl.stb.STBImage.*;
 import static org.lwjgl.vulkan.VK10.*;
@@ -28,31 +26,10 @@ import static org.lwjgl.vulkan.VK10.*;
  * @author maeda6uiui
  */
 public class VkMttTexture {
-    private static final Map<Integer, Boolean> allocationStatus;
     private static int imageFormat;
 
     static {
-        allocationStatus = new HashMap<>();
-        for (int i = 0; i < GBufferNabor.MAX_NUM_TEXTURES; i++) {
-            allocationStatus.put(i, false);
-        }
-
         imageFormat = VK_FORMAT_R8G8B8A8_SRGB;
-    }
-
-    private synchronized static int allocateTextureIndex() {
-        int index = -1;
-
-        for (var entry : allocationStatus.entrySet()) {
-            if (!entry.getValue()) {
-                index = entry.getKey();
-                allocationStatus.put(index, true);
-
-                break;
-            }
-        }
-
-        return index;
     }
 
     public static void setImageFormatToSRGB() {
@@ -339,7 +316,7 @@ public class VkMttTexture {
             VkMttScreen screen,
             Path textureFile,
             boolean generateMipmaps) {
-        allocationIndex = allocateTextureIndex();
+        allocationIndex = VkMttScreen.allocateTextureIndex();
         if (allocationIndex < 0) {
             String msg = String.format("Cannot create more than %d textures", GBufferNabor.MAX_NUM_TEXTURES);
             throw new RuntimeException(msg);
@@ -370,7 +347,7 @@ public class VkMttTexture {
             int width,
             int height,
             boolean generateMipmaps) {
-        allocationIndex = allocateTextureIndex();
+        allocationIndex = VkMttScreen.allocateTextureIndex();
         if (allocationIndex < 0) {
             String msg = String.format("Cannot create more than %d textures", GBufferNabor.MAX_NUM_TEXTURES);
             throw new RuntimeException(msg);
@@ -392,7 +369,7 @@ public class VkMttTexture {
     }
 
     public VkMttTexture(VkDevice device, VkMttScreen screen, long imageView) {
-        allocationIndex = allocateTextureIndex();
+        allocationIndex = VkMttScreen.allocateTextureIndex();
         if (allocationIndex < 0) {
             String msg = String.format("Cannot create more than %d textures", GBufferNabor.MAX_NUM_TEXTURES);
             throw new RuntimeException(msg);
@@ -415,9 +392,7 @@ public class VkMttTexture {
             vkDestroyImageView(device, textureImageView, null);
         }
 
-        synchronized (allocationStatus) {
-            allocationStatus.put(allocationIndex, false);
-        }
+        VkMttScreen.deallocateTexture(allocationIndex);
         screen.resetTextureDescriptorSets(allocationIndex);
     }
 

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/texture/VkMttTexture.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/screen/texture/VkMttTexture.java
@@ -11,6 +11,8 @@ import com.github.maeda6uiui.mechtatel.core.vulkan.util.ImageUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.vulkan.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
@@ -26,6 +28,8 @@ import static org.lwjgl.vulkan.VK10.*;
  * @author maeda6uiui
  */
 public class VkMttTexture {
+    private static final Logger logger = LoggerFactory.getLogger(VkMttTexture.class);
+
     private static int imageFormat;
 
     static {
@@ -57,6 +61,8 @@ public class VkMttTexture {
 
     private Path textureFile;
     private boolean generateMipmaps;
+
+    private Runnable fDeallocateTexture;
 
     private void memcpy(ByteBuffer dst, ByteBuffer src, long size) {
         src.limit((int) size);
@@ -316,11 +322,14 @@ public class VkMttTexture {
             VkMttScreen screen,
             Path textureFile,
             boolean generateMipmaps) {
-        allocationIndex = VkMttScreen.allocateTextureIndex();
+        allocationIndex = screen.allocateTextureIndex();
         if (allocationIndex < 0) {
             String msg = String.format("Cannot create more than %d textures", GBufferNabor.MAX_NUM_TEXTURES);
             throw new RuntimeException(msg);
         }
+        fDeallocateTexture = () -> {
+            screen.deallocateTexture(allocationIndex);
+        };
 
         this.device = device;
 
@@ -347,11 +356,14 @@ public class VkMttTexture {
             int width,
             int height,
             boolean generateMipmaps) {
-        allocationIndex = VkMttScreen.allocateTextureIndex();
+        allocationIndex = screen.allocateTextureIndex();
         if (allocationIndex < 0) {
             String msg = String.format("Cannot create more than %d textures", GBufferNabor.MAX_NUM_TEXTURES);
             throw new RuntimeException(msg);
         }
+        fDeallocateTexture = () -> {
+            screen.deallocateTexture(allocationIndex);
+        };
 
         this.device = device;
 
@@ -369,11 +381,14 @@ public class VkMttTexture {
     }
 
     public VkMttTexture(VkDevice device, VkMttScreen screen, long imageView) {
-        allocationIndex = VkMttScreen.allocateTextureIndex();
+        allocationIndex = screen.allocateTextureIndex();
         if (allocationIndex < 0) {
             String msg = String.format("Cannot create more than %d textures", GBufferNabor.MAX_NUM_TEXTURES);
             throw new RuntimeException(msg);
         }
+        fDeallocateTexture = () -> {
+            screen.deallocateTexture(allocationIndex);
+        };
 
         this.device = device;
         this.textureImageView = imageView;
@@ -392,7 +407,12 @@ public class VkMttTexture {
             vkDestroyImageView(device, textureImageView, null);
         }
 
-        VkMttScreen.deallocateTexture(allocationIndex);
+        if (fDeallocateTexture != null) {
+            fDeallocateTexture.run();
+        } else {
+            logger.warn("Cannot deallocate texture because fDeallocateTexture is null");
+        }
+
         screen.resetTextureDescriptorSets(allocationIndex);
     }
 

--- a/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/core/OutOfBoundsTextureAllocationIndexTest.java
+++ b/mechtatel-core/src/test/java/com/github/maeda6uiui/mechtatel/core/OutOfBoundsTextureAllocationIndexTest.java
@@ -1,0 +1,31 @@
+package com.github.maeda6uiui.mechtatel.core;
+
+import com.github.maeda6uiui.mechtatel.core.screen.MttScreen;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OutOfBoundsTextureAllocationIndexTest extends Mechtatel {
+    private static final Logger logger = LoggerFactory.getLogger(OutOfBoundsTextureAllocationIndexTest.class);
+
+    public OutOfBoundsTextureAllocationIndexTest(MttSettings settings) {
+        super(settings);
+        this.run();
+    }
+
+    public static void main(String[] args) {
+        MttSettings
+                .load("./Mechtatel/settings.json")
+                .ifPresentOrElse(
+                        OutOfBoundsTextureAllocationIndexTest::new,
+                        () -> logger.error("Failed to load settings")
+                );
+    }
+
+    @Override
+    public void onCreate(MttWindow window) {
+        MttScreen defaultScreen = window.getDefaultScreen();
+
+        //This should throw an exception.
+        defaultScreen.getVulkanScreen().deallocateTexture(-1);
+    }
+}


### PR DESCRIPTION
# Overview

Manage texture allocation indices in VkMttScreen as textures are bound to a screen.
