### PR TITLE
Improve code for lighting

### DIFF
--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/postprocessing/light/PointLight.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/postprocessing/light/PointLight.java
@@ -2,11 +2,19 @@ package com.github.maeda6uiui.mechtatel.core.postprocessing.light;
 
 import org.joml.Vector3f;
 
-/**
- * Point light
- *
- * @author maeda6uiui
- */
+/// Parameters for a point light
+///
+/// A point light is like a spotlight, but it doesn't have a lighting direction.
+/// The attenuation is calculated just the same as spotlight.
+/// ```
+/// attenuation = 1 / (k0 + k1 * r + k2 * r^2)
+/// ```
+/// where `r` is the distance between the fragment and the light.
+///
+/// Unlike spotlights, point lights can't be used for shadow mapping,
+/// as it doesn't have the direction and therefore the direction of the shadow can't be established.
+///
+/// @author maeda6uiui
 public class PointLight {
     private Vector3f position;
     private Vector3f diffuseColor;

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/postprocessing/light/Spotlight.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/postprocessing/light/Spotlight.java
@@ -12,7 +12,7 @@ import org.joml.Vector3f;
 /// Don't confuse it with the `attenuations` parameter, which is used for shadow mapping.
 ///
 /// The actual attenuation is then obtained by multiplying the falloff of the light
-/// when the fragment is in between the inner and the outer corns of the light.
+/// when the fragment is in between the inner and the outer cones of the light.
 ///
 /// The following parameters are used for shadow mapping:
 /// `castShadow`, `center`, `fovY`, `aspect`, `zNear`, `zFar`, and `attenuations`.
@@ -30,8 +30,8 @@ public class Spotlight {
     private float k0;
     private float k1;
     private float k2;
-    private float theta; //inner corn
-    private float phi; //outer corn
+    private float theta; //inner cone
+    private float phi; //outer cone
     private float falloff;
     private float specularPowY;
 
@@ -171,12 +171,12 @@ public class Spotlight {
         this.theta = theta;
     }
 
-    public float getInnerCorn() {
+    public float getInnerCone() {
         return getTheta();
     }
 
-    public void setInnerCorn(float innerCorn) {
-        setTheta(innerCorn);
+    public void setInnerCone(float innerCone) {
+        setTheta(innerCone);
     }
 
     @Deprecated
@@ -189,12 +189,12 @@ public class Spotlight {
         this.phi = phi;
     }
 
-    public float getOuterCorn() {
+    public float getOuterCone() {
         return getPhi();
     }
 
-    public void setOuterCorn(float outerCorn) {
-        setPhi(outerCorn);
+    public void setOuterCone(float outerCone) {
+        setPhi(outerCone);
     }
 
     public float getFalloff() {

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/postprocessing/light/Spotlight.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/postprocessing/light/Spotlight.java
@@ -2,7 +2,7 @@ package com.github.maeda6uiui.mechtatel.core.postprocessing.light;
 
 import org.joml.Vector3f;
 
-/// Parameters for spotlight
+/// Parameters for a spotlight
 ///
 /// The base attenuation of the light is calculated by the following formula:
 /// ```
@@ -11,7 +11,11 @@ import org.joml.Vector3f;
 /// where `r` is the distance between the fragment and the light.
 /// Don't confuse it with the `attenuations` parameter, which is used for shadow mapping.
 ///
-/// The actual attenuation is then obtained by multiplying the falloff of the light.
+/// The actual attenuation is then obtained by multiplying the falloff of the light
+/// when the fragment is in between the inner and the outer corns of the light.
+///
+/// The following parameters are used for shadow mapping:
+/// `castShadow`, `center`, `fovY`, `aspect`, `zNear`, `zFar`, and `attenuations`.
 ///
 /// @author maeda6uiui
 public class Spotlight {

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/postprocessing/light/Spotlight.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/postprocessing/light/Spotlight.java
@@ -30,8 +30,8 @@ public class Spotlight {
     private float k0;
     private float k1;
     private float k2;
-    private float theta; //inner cone
-    private float phi; //outer cone
+    private float innerCone;
+    private float outerCone;
     private float falloff;
     private float specularPowY;
 
@@ -55,8 +55,8 @@ public class Spotlight {
         k0 = 0.0f;
         k1 = 0.0f;
         k2 = 0.01f;
-        theta = (float) Math.toRadians(20);
-        phi = (float) Math.toRadians(50);
+        innerCone = (float) Math.toRadians(20);
+        outerCone = (float) Math.toRadians(50);
         falloff = 2.0f;
         specularPowY = 2.0f;
 
@@ -163,38 +163,38 @@ public class Spotlight {
 
     @Deprecated
     public float getTheta() {
-        return theta;
+        return innerCone;
     }
 
     @Deprecated
     public void setTheta(float theta) {
-        this.theta = theta;
+        this.innerCone = theta;
     }
 
     public float getInnerCone() {
-        return getTheta();
+        return innerCone;
     }
 
     public void setInnerCone(float innerCone) {
-        setTheta(innerCone);
+        this.innerCone = innerCone;
     }
 
     @Deprecated
     public float getPhi() {
-        return phi;
+        return outerCone;
     }
 
     @Deprecated
     public void setPhi(float phi) {
-        this.phi = phi;
+        this.outerCone = phi;
     }
 
     public float getOuterCone() {
-        return getPhi();
+        return outerCone;
     }
 
     public void setOuterCone(float outerCone) {
-        setPhi(outerCone);
+        this.outerCone = outerCone;
     }
 
     public float getFalloff() {

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/postprocessing/light/Spotlight.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/postprocessing/light/Spotlight.java
@@ -2,11 +2,18 @@ package com.github.maeda6uiui.mechtatel.core.postprocessing.light;
 
 import org.joml.Vector3f;
 
-/**
- * Spotlight
- *
- * @author maeda6uiui
- */
+/// Parameters for spotlight
+///
+/// The base attenuation of the light is calculated by the following formula:
+/// ```
+/// attenuation = 1 / (k0 + k1 * r + k2 * r^2)
+/// ```
+/// where `r` is the distance between the fragment and the light.
+/// Don't confuse it with the `attenuations` parameter, which is used for shadow mapping.
+///
+/// The actual attenuation is then obtained by multiplying the falloff of the light.
+///
+/// @author maeda6uiui
 public class Spotlight {
     private Vector3f position;
     private Vector3f direction;
@@ -150,20 +157,40 @@ public class Spotlight {
         this.k2 = k2;
     }
 
+    @Deprecated
     public float getTheta() {
         return theta;
     }
 
+    @Deprecated
     public void setTheta(float theta) {
         this.theta = theta;
     }
 
+    public float getInnerCorn() {
+        return getTheta();
+    }
+
+    public void setInnerCorn(float innerCorn) {
+        setTheta(innerCorn);
+    }
+
+    @Deprecated
     public float getPhi() {
         return phi;
     }
 
+    @Deprecated
     public void setPhi(float phi) {
         this.phi = phi;
+    }
+
+    public float getOuterCorn() {
+        return getPhi();
+    }
+
+    public void setOuterCorn(float outerCorn) {
+        setPhi(outerCorn);
     }
 
     public float getFalloff() {

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/ubo/postprocessing/SpotlightUBO.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/ubo/postprocessing/SpotlightUBO.java
@@ -44,8 +44,8 @@ public class SpotlightUBO extends UBO {
         k0 = spotlight.getK0();
         k1 = spotlight.getK1();
         k2 = spotlight.getK2();
-        theta = spotlight.getTheta();
-        phi = spotlight.getPhi();
+        theta = spotlight.getInnerCone();
+        phi = spotlight.getOuterCone();
         falloff = spotlight.getFalloff();
         specularPowY = spotlight.getSpecularPowY();
     }

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/ubo/postprocessing/SpotlightUBO.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/ubo/postprocessing/SpotlightUBO.java
@@ -27,8 +27,8 @@ public class SpotlightUBO extends UBO {
     private float k0;
     private float k1;
     private float k2;
-    private float theta;
-    private float phi;
+    private float innerCone;
+    private float outerCone;
     private float falloff;
     private float specularPowY;
 
@@ -44,8 +44,8 @@ public class SpotlightUBO extends UBO {
         k0 = spotlight.getK0();
         k1 = spotlight.getK1();
         k2 = spotlight.getK2();
-        theta = spotlight.getInnerCone();
-        phi = spotlight.getOuterCone();
+        innerCone = spotlight.getInnerCone();
+        outerCone = spotlight.getOuterCone();
         falloff = spotlight.getFalloff();
         specularPowY = spotlight.getSpecularPowY();
     }
@@ -63,8 +63,8 @@ public class SpotlightUBO extends UBO {
         buffer.putFloat(SIZEOF_VEC4 * 7 + SIZEOF_VEC3, k0);
         buffer.putFloat(SIZEOF_VEC4 * 8, k1);
         buffer.putFloat(SIZEOF_VEC4 * 8 + SIZEOF_FLOAT, k2);
-        buffer.putFloat(SIZEOF_VEC4 * 8 + SIZEOF_FLOAT * 2, theta);
-        buffer.putFloat(SIZEOF_VEC4 * 8 + SIZEOF_FLOAT * 3, phi);
+        buffer.putFloat(SIZEOF_VEC4 * 8 + SIZEOF_FLOAT * 2, innerCone);
+        buffer.putFloat(SIZEOF_VEC4 * 8 + SIZEOF_FLOAT * 3, outerCone);
         buffer.putFloat(SIZEOF_VEC4 * 9, falloff);
         buffer.putFloat(SIZEOF_VEC4 * 9 + SIZEOF_FLOAT, specularPowY);
 

--- a/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/ubo/postprocessing/SpotlightUBO.java
+++ b/mechtatel-core/src/main/java/com/github/maeda6uiui/mechtatel/core/vulkan/ubo/postprocessing/SpotlightUBO.java
@@ -48,6 +48,13 @@ public class SpotlightUBO extends UBO {
         outerCone = spotlight.getOuterCone();
         falloff = spotlight.getFalloff();
         specularPowY = spotlight.getSpecularPowY();
+
+        if (innerCone > outerCone) {
+            throw new IllegalArgumentException("The inner cone cannot be larger than the outer cone");
+        }
+        if (specularPowY < 0.0f) {
+            throw new IllegalArgumentException("The specular power cannot be smaller than zero");
+        }
     }
 
     @Override

--- a/mechtatel-core/src/main/resources/Standard/Shader/PostProcessing/spotlight.frag.glsl
+++ b/mechtatel-core/src/main/resources/Standard/Shader/PostProcessing/spotlight.frag.glsl
@@ -81,7 +81,7 @@ void main(){
             float specularCoefficient=pow(clamp(dot(normal,halfLE),0.0,1.0),lights[i].specularPowY);
 
             vec3 diffuseColor=lights[i].diffuseColor*attenuation;
-            vec3 specularColor=lights[i].specularColor*attenuation;
+            vec3 specularColor=lights[i].specularColor*specularCoefficient*attenuation;
 
             diffuseColor=clamp(diffuseColor,lights[i].diffuseClampMin,lights[i].diffuseClampMax);
             specularColor=clamp(specularColor,lights[i].specularClampMin,lights[i].specularClampMax);

--- a/mechtatel-core/src/main/resources/Standard/Shader/PostProcessing/spotlight.frag.glsl
+++ b/mechtatel-core/src/main/resources/Standard/Shader/PostProcessing/spotlight.frag.glsl
@@ -28,8 +28,8 @@ struct Spotlight{
     float k0;
     float k1;
     float k2;
-    float theta;
-    float phi;
+    float innerCone;
+    float outerCone;
     float falloff;
     float specularPowY;
 };
@@ -66,15 +66,15 @@ void main(){
         r=normalize(r);
 
         float cosAlpha=dot(r,lights[i].direction);
-        float cosHalfTheta=cos(lights[i].theta/2.0);
-        float cosHalfPhi=cos(lights[i].phi/2.0);
+        float cosHalfInnerCone=cos(lights[i].innerCone/2.0);
+        float cosHalfOuterCone=cos(lights[i].outerCone/2.0);
 
         vec3 spotlightColor;
-        if(cosAlpha<=cosHalfPhi){
+        if(cosAlpha<=cosHalfOuterCone){
             spotlightColor=vec3(0.0);
         }else{
-            if(cosAlpha<=cosHalfTheta){
-                attenuation*=pow((cosAlpha-cosHalfPhi)/(cosHalfTheta-cosHalfPhi),lights[i].falloff);
+            if(cosAlpha<=cosHalfInnerCone){
+                attenuation*=pow((cosAlpha-cosHalfOuterCone)/(cosHalfInnerCone-cosHalfOuterCone),lights[i].falloff);
             }
 
             vec3 halfLE=-normalize(cameraDirection+lights[i].direction);


### PR DESCRIPTION
# Overview

- Deprecates some getters and setters in Spotlight
- Add Javadoc comments to Spotlight and PointLight
  - Used Markdown, so update to Java >= 23 is required

I'm going to update the required Java version to Java >= 25 in a different PR.
