### PR TITLE
Update Windows x64 test status to 'No'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Its somewhat cheap taste of 20-year-old gameplay still captivates me.
 |-------------|--------|
 | Linux x64   | Yes    |
 | Linux arm64 | No     |
-| Windows x64 | Yes    |
+| Windows x64 | No     |
 | macOS arm64 | No     |
 
 Support for Linux arm64 is partly tested on a `g5g.xlarge` instance of AWS EC2.


### PR DESCRIPTION
# Overview

#147 changed the way Windows DLLs for Slang are loaded.
It is yet to be tested on Windows x64.
